### PR TITLE
Lock account on failed attempts

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -563,30 +563,21 @@ class S3Config(Storage):
         """
         return self.auth.get("log_failed_logins", False)
 
-    def get_auth_lock_failed_logins(self):
-        """
-            Lock failed logins, options:
-                - True          : lock all failed logins
-                - False         : do not lock failed logins
-        """
-        return self.auth.get("lock_failed_logins", False)
-
     def get_auth_lock_failed_login_count(self):
         """
             Lock failed logins count
-            None or 0 means use default (currently 5)
         """
-        failed_login_count = self.auth.get("lock_failed_login_count", 0)
+        failed_login_count = self.auth.get("lock_failed_login_count", int(0))
         if isinstance(failed_login_count, int) and failed_login_count > 0:
             return failed_login_count
-        return 5
+        return 0
 
     def get_auth_lock_failed_login_reset(self):
         """
             Lock failed logins reset duration in seconds
-            None or 0 means use default (currently 300)
+            - defaults to 5 minutes
         """
-        failed_login_reset = self.auth.get("lock_failed_login_reset", 0)
+        failed_login_reset = self.auth.get("lock_failed_login_reset", int(0))
         if isinstance(failed_login_reset, int) and failed_login_reset > 0:
             return failed_login_reset
         return 300

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -563,6 +563,34 @@ class S3Config(Storage):
         """
         return self.auth.get("log_failed_logins", False)
 
+    def get_auth_lock_failed_logins(self):
+        """
+            Lock failed logins, options:
+                - True          : lock all failed logins
+                - False         : do not lock failed logins
+        """
+        return self.auth.get("lock_failed_logins", False)
+
+    def get_auth_lock_failed_login_count(self):
+        """
+            Lock failed logins count
+            None or 0 means use default (currently 5)
+        """
+        failed_login_count = self.auth.get("lock_failed_login_count", 0)
+        if isinstance(failed_login_count, int) and failed_login_count > 0:
+            return failed_login_count
+        return 5
+
+    def get_auth_lock_failed_login_reset(self):
+        """
+            Lock failed logins reset duration in seconds
+            None or 0 means use default (currently 300)
+        """
+        failed_login_reset = self.auth.get("lock_failed_login_reset", 0)
+        if isinstance(failed_login_reset, int) and failed_login_reset > 0:
+            return failed_login_reset
+        return 300
+
     def get_auth_password_changes(self):
         """
             Are password changes allowed?


### PR DESCRIPTION
This pull request adds a user account lockout feature to the authentication system, which helps prevent brute-force login attempts by temporarily locking accounts after a configurable number of failed login attempts. The implementation introduces new configuration options, updates messaging, and modifies the login logic to track and enforce lockouts.

### Account Lockout Feature

* Added logic in `auth.py` to track failed login attempts and lock user accounts for a configurable duration (`lock_failed_login_reset`) after exceeding a configurable threshold (`lock_failed_login_count`). The system now checks if an account is locked before allowing login attempts and displays an appropriate error message if locked. [[1]](diffhunk://#diff-e945de4bd7744ce8918773013cdb17368704e6fd2a300a97010d643062667f24R712-R718) [[2]](diffhunk://#diff-e945de4bd7744ce8918773013cdb17368704e6fd2a300a97010d643062667f24R786-R799)

* Introduced new configuration methods in `s3cfg.py`: `get_auth_lock_failed_login_count` and `get_auth_lock_failed_login_reset`, allowing deployment-specific settings for the maximum failed login attempts and lockout duration.

### Messaging Updates

* Added new messages for account lockout events and exceeded login attempts to the authentication messages object, improving feedback for both users and system logs.

### Dependency Updates

* Imported the `datetime` module in `auth.py` to support time-based lockout logic.

### Internal Logic Changes

* Retrieved lockout configuration values during login processing to determine when to lock accounts and for how long.