### PR TITLE
Replace s3_requires_membership with requires_membership

### DIFF
--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -12,7 +12,7 @@ def index():
             }
 
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def setting():
     """
         Custom page to link to those Settings which can be edited through
@@ -24,7 +24,7 @@ def setting():
 # =============================================================================
 # AAA
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def role():
     """ Role Manager """
 
@@ -423,7 +423,7 @@ def group():
     return crud_controller("auth", "group")
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def organisation():
     """
         RESTful CRUD controller
@@ -460,7 +460,7 @@ def user_create_onvalidation (form):
 # =============================================================================
 # Audit
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def audit():
     """ Audit Logs: RESTful CRUD Controller """
 
@@ -475,7 +475,7 @@ def audit():
     return crud_controller("s3", "audit")
 
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def event():
     """
         CRUD controller for Auth event log
@@ -518,7 +518,7 @@ def event():
 # =============================================================================
 # Consent Tracking
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def processing_type():
     """ Types of Data Processing: RESTful CRUD Controller """
 
@@ -528,7 +528,7 @@ def processing_type():
                            )
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def consent_option():
     """ Consent Options: RESTful CRUD Controller """
 
@@ -599,7 +599,7 @@ def consent_option():
                            )
 
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def consent():
 
     return crud_controller("auth", "consent")
@@ -608,7 +608,7 @@ def consent():
 # Ticket viewing
 # - web2Py ticket viewer functions borrowed from admin application of web2py
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def errors():
     """ Error ticket list """
 
@@ -629,7 +629,7 @@ def errors():
             }
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def ticket():
     """ Ticket viewer """
 
@@ -654,7 +654,7 @@ def ticket():
 # =============================================================================
 # Create portable app
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def portable():
     """ Portable app creator"""
 
@@ -826,7 +826,7 @@ def create_portable_app(web2py_source, copy_database=False, copy_uploads=False):
     return response.stream(portable_app)
 
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def task():
     """
         Scheduler tasks: RESTful CRUD controller

--- a/controllers/irs.py
+++ b/controllers/irs.py
@@ -17,7 +17,7 @@ def index():
     return dict(module_name=module_name)
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def icategory():
     """
         Incident Categories, RESTful controller

--- a/controllers/msg.py
+++ b/controllers/msg.py
@@ -682,7 +682,7 @@ def tropo():
         pass
 
 # =============================================================================
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def sms_outbound_gateway():
     """ SMS Outbound Gateway selection for the messaging framework """
 
@@ -1158,7 +1158,7 @@ def twilio_channel():
     return crud_controller()
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def sms_modem_channel():
     """
         RESTful CRUD controller for modem channels
@@ -1203,7 +1203,7 @@ def sms_modem_channel():
     return crud_controller()
 
 #------------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def sms_smtp_channel():
     """
         RESTful CRUD controller for SMTP to SMS Outbound channels
@@ -1245,7 +1245,7 @@ def sms_smtp_channel():
     return crud_controller()
 
 #------------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def sms_webapi_channel():
     """
         RESTful CRUD controller for Web API channels
@@ -1299,7 +1299,7 @@ def sms_webapi_channel():
     return crud_controller()
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def tropo_channel():
     """
         RESTful CRUD controller for Tropo channels
@@ -1331,7 +1331,7 @@ def tropo_channel():
     return crud_controller()
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def twitter_channel():
     """
         RESTful CRUD controller for Twitter channels
@@ -2071,7 +2071,7 @@ def process_twitter_outbox():
 # =============================================================================
 # Enabled only for testing:
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def facebook_post():
     """ Post to Facebook """
 
@@ -2152,7 +2152,7 @@ def facebook_post():
 # =============================================================================
 # Enabled only for testing:
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def twitter_post():
     """ Post to Twitter """
 
@@ -2233,7 +2233,7 @@ def twitter_post():
 # =============================================================================
 # Enabled only for testing:
 #
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def tag():
     """ RESTful CRUD controller """
 

--- a/controllers/xforms.py
+++ b/controllers/xforms.py
@@ -368,7 +368,7 @@ def importxml(db, xmlinput):
     db[parent].import_from_csv_file(fh)
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(1)
+@auth.requires_membership(1)
 def post():
     """
         @todo: deprecate
@@ -455,7 +455,7 @@ def submission():
         raise HTTP(status, result)
 
 # -----------------------------------------------------------------------------
-@auth.s3_requires_membership(2)
+@auth.requires_membership(2)
 def submission_old():
     """
         Allows for submission of xforms by ODK Collect


### PR DESCRIPTION
Refactored controllers to use auth.requires_membership instead of the deprecated auth.s3_requires_membership. Updated AuthS3 class to override has_membership and requires_membership methods, ensuring deleted flag is respected in membership checks and consistent with web2py authorization methods.