### PR TITLE
Tweak web2py install instructions

### DIFF
--- a/docs/source/dev/setup.rst
+++ b/docs/source/dev/setup.rst
@@ -59,7 +59,7 @@ To install web2py, clone it directly from GitHub:
 
 .. code-block:: bash
 
-   git clone --recursive https://github.com/web2py/web2py.git ~/web2py
+   git clone https://github.com/web2py/web2py.git ~/web2py
 
 .. tip::
    You can of course choose any other target location than *~/web2py* for
@@ -72,7 +72,7 @@ all submodules) to the supported stable version (currently 2.27.1):
 
    cd ~/web2py
    git reset --hard 49bb23c4
-   git submodule update --recursive
+   git submodule update --init --recursive
 
 Installing Eden
 ---------------

--- a/tests/travis/install_web2py.sh
+++ b/tests/travis/install_web2py.sh
@@ -19,13 +19,13 @@ WEB2PY_COMMIT=49bb23c4
 
 # Clone web2py under build home (usually /home/travis/build)
 cd ../..
-git clone --recursive https://github.com/web2py/web2py.git
+git clone https://github.com/web2py/web2py.git
 
 # Reset to target version
 cd web2py
 if [ ! -z "$WEB2PY_COMMIT" ]; then
    git reset --hard $WEB2PY_COMMIT
-   git submodule update --recursive
+   git submodule update --init --recursive
 fi
 
 # Patch web2py/PyDAL


### PR DESCRIPTION
I know this is not related to the emergency work, but it is something I found while my compatriots and I were trying to install web2py. Please ignore this until it is more convenient for you.

This pull request updates the instructions and scripts for installing web2py by simplifying the git clone command and ensuring proper initialization of submodules. These changes help prevent potential issues with missing submodules and make the installation process more reliable.

**Installation script and documentation improvements: **

* Updated the `git clone` command in both `docs/source/dev/setup.rst` and `tests/travis/install_web2py.sh` to remove the `--recursive` flag, making the clone step simpler and more consistent. [[1]](diffhunk://#diff-0f89111209a95b090c8ff1e379a7df022f2597f5e7954808e0ee2c990bd20714L62-R62) [[2]](diffhunk://#diff-1a20035be84dd094d6968416e8a57b40297da0741f2311cf71382da6ec4462dbL22-R28)
* Changed the submodule update command to `git submodule update --init --recursive` in both documentation and installation script, ensuring that submodules are properly initialized after checkout. [[1]](diffhunk://#diff-0f89111209a95b090c8ff1e379a7df022f2597f5e7954808e0ee2c990bd20714L75-R75) [[2]](diffhunk://#diff-1a20035be84dd094d6968416e8a57b40297da0741f2311cf71382da6ec4462dbL22-R28)