### PR TITLE
FIX: Correct quotes and remove extraneous code

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -4432,12 +4432,6 @@ class S3Config(Storage):
         """
         return self.inv.get("direct_stock_edits", False)
 
-    #def get_inv_org_dependent_warehouse_types(self):
-    #    """
-    #        Whether Warehouse Types vary by Organisation
-    #    """
-    #    return self.inv.get("org_dependent_warehouse_types", False)
-
     def get_inv_send_show_mode_of_transport(self):
         """
             Show mode of transport on Sent Shipments
@@ -4530,12 +4524,6 @@ class S3Config(Storage):
 
     def get_inv_recv_shortname(self):
         return self.inv.get("recv_shortname", "GRN")
-
-    #def get_inv_warehouse_code_unique(self):
-    #    """
-    #        Validate for Unique Warehouse Codes
-    #    """
-    #    return self.inv.get("warehouse_code_unique", False)
 
     # -------------------------------------------------------------------------
     # IRS

--- a/modules/s3db/inv.py
+++ b/modules/s3db/inv.py
@@ -141,16 +141,6 @@ class InvWarehouseModel(DataModel):
 
         organisation_id = self.org_organisation_id
 
-        # ADMIN = current.session.s3.system_roles.ADMIN
-        is_admin = auth.s3_has_role("ADMIN")
-
-        #root_org = auth.root_org()
-        #if is_admin:
-        #    filter_opts = (None,)
-        #elif root_org:
-        #    filter_opts = (root_org, None)
-        #else:
-        #    filter_opts = (None,)
 
         # ---------------------------------------------------------------------
         # Warehouse Types

--- a/modules/s3db/inv.py
+++ b/modules/s3db/inv.py
@@ -142,7 +142,7 @@ class InvWarehouseModel(DataModel):
         organisation_id = self.org_organisation_id
 
         # ADMIN = current.session.s3.system_roles.ADMIN
-        is_admin = auth.s3_has_role('ADMIN')
+        is_admin = auth.s3_has_role("ADMIN")
 
         #root_org = auth.root_org()
         #if is_admin:
@@ -166,10 +166,6 @@ class InvWarehouseModel(DataModel):
                                        IS_NOT_ONE_OF(db, "%s.name" % tablename,),
                                       ],
                            ),
-                     #organisation_id(default = root_org if org_dependent_wh_types else None,
-                     #                readable = is_admin if org_dependent_wh_types else False,
-                     #                writable = is_admin if org_dependent_wh_types else False,
-                     #                ),
                      CommentsField(),
                      )
 

--- a/modules/templates/DIRECT/menus.py
+++ b/modules/templates/DIRECT/menus.py
@@ -227,13 +227,13 @@ class OptionsMenu(default.OptionsMenu):
 
         return M()(
                     M("Warehouses", c="inv", f="warehouse")(
-                        M("Create", m="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
-                        M("Import", m="import", p="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Create", m="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
+                        M("Import", m="import", p="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                     ),
                     M("Warehouse Stock", c="inv", f="inv_item")(
-                        M("Adjust Stock Levels", f="adj", check=use_adjust, restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Adjust Stock Levels", f="adj", check=use_adjust, restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                         # M("Kitting", f="kitting"),
-                        M("Import", f="inv_item", m="import", p="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Import", f="inv_item", m="import", p="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                     ),
                     # M("Reports", c="inv", f="inv_item")(
                     #     M("Warehouse Stock", f="inv_item", m="report"),
@@ -249,18 +249,18 @@ class OptionsMenu(default.OptionsMenu):
                     #       vars={"report": "rel"}),
                     # ),
                     M(inv_recv_list, c="inv", f="recv", translate=False)( # Already T()
-                        M("Create", m="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Create", m="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                     ),
                     M("Sent Shipments", c="inv", f="send")(
-                        M("Create", m="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Create", m="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                         M("Search Shipped Items", f="track_item"),
                     ),
                     M("Distributions", c="supply", f="distribution")(
-                        M("Create", m="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Create", m="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                     ),
                     M("Items", c="supply", f="item")(
-                        M("Create", m="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
-                        M("Import", f="catalog_item", m="import", p="create", restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR']),
+                        M("Create", m="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
+                        M("Import", f="catalog_item", m="import", p="create", restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"]),
                     ),
                     # Catalog Items moved to be next to the Item Categories
                     #M("Catalog Items", c="supply", f="catalog_item")(
@@ -271,7 +271,7 @@ class OptionsMenu(default.OptionsMenu):
                     #    M("Create", m="create"),
                     #),
 
-                    M("Administration", c=("supply", "inv"), restrict=['ADMIN', 'ORG_ADMIN', 'SUPPLY_COORDINATOR'], link=False)(
+                    M("Administration", c=("supply", "inv"), restrict=["ADMIN", "ORG_ADMIN", "SUPPLY_COORDINATOR"], link=False)(
                         M("Catalogs", f="catalog"),
                         M("Item Categories", f="item_category"),
                         M("Warehouse Types", c="inv", f="warehouse_type"),


### PR DESCRIPTION
This pull request primarily focuses on code cleanup and consistency improvements in the inventory management modules. The changes include removing commented-out legacy code, standardizing string formatting for role checks, and ensuring uniform use of list syntax for role restrictions in menu definitions.

**Code cleanup and removal of legacy code:**

* Removed commented-out methods and parameters related to organization-dependent warehouse types and unique warehouse code validation in `modules/s3cfg.py` and `modules/s3db/inv.py` to reduce clutter and improve maintainability. [[1]](diffhunk://#diff-4adb26ef67350c852add93138d7915ccd5730a9ef4ba9a1f91f6e26eec4fa179L4435-L4440) [[2]](diffhunk://#diff-4adb26ef67350c852add93138d7915ccd5730a9ef4ba9a1f91f6e26eec4fa179L4534-L4539) [[3]](diffhunk://#diff-172c6e8265f8a27312de8e85a0bfd8dcb1c5cd12383348770a811d5ffc52bcd9L169-L172)

**Consistency improvements:**

* Standardized the use of double quotes for role names in permission checks, replacing single quotes in `modules/s3db/inv.py`.
* Updated all `restrict` parameters in menu definitions to use list syntax with double quotes for role names in `modules/templates/DIRECT/menus.py`, improving consistency and readability. [[1]](diffhunk://#diff-c94593630ebec8b5fd55f4c7bc954dc05909f17772dc7029bc560447fedeaa2eL230-R236) [[2]](diffhunk://#diff-c94593630ebec8b5fd55f4c7bc954dc05909f17772dc7029bc560447fedeaa2eL252-R263) [[3]](diffhunk://#diff-c94593630ebec8b5fd55f4c7bc954dc05909f17772dc7029bc560447fedeaa2eL274-R274)