### PR TITLE
Fix #15: Prevent IndexError crash when registering vehicles

### DIFF
--- a/controllers/vehicle.py
+++ b/controllers/vehicle.py
@@ -77,7 +77,9 @@ def vehicle():
                               tooltip=T("Only Items whose Category are of type 'Vehicle' will be seen in the dropdown."))
 
     # Use this controller for options.json rather than looking for one called 'asset'
-    table.organisation_id.comment[0].vars = dict(parent="vehicle")
+    # Safely update comment vars if comment exists and is indexable
+    if table.organisation_id.comment and hasattr(table.organisation_id.comment, '__getitem__'):
+        table.organisation_id.comment[0].vars = dict(parent="vehicle")
 
     # Only select from vehicles
     field.widget = None # We want a simple dropdown


### PR DESCRIPTION
## Summary
Fixes the IndexError crash that occurs when attempting to register a new vehicle in the default template.

Resolves #15

## Problem
**Steps to reproduce:**
1. Navigate to: More => Vehicles
2. Click: Vehicles => Create
3. **Crash**: `IndexError: list index out of range`

This blocks emergency responders from registering vehicles needed for disaster relief operations (ambulances, rescue vehicles, supply trucks).

## Root Cause
Line 80 in `controllers/vehicle.py` unsafely accesses `comment[0]`:

```python
table.organisation_id.comment[0].vars = dict(parent="vehicle")
```

**The assumption:** `organisation_id.comment` is always a non-empty list

**The reality:** `comment` can be:
- `None` (when no comment widget is configured for the field)
- Empty list/tuple
- A non-indexable object

When `comment` is None or empty, accessing `[0]` raises `IndexError: list index out of range`.

## Solution
Added defensive check before accessing the index:

```python
# Safely update comment vars if comment exists and is indexable
if table.organisation_id.comment and hasattr(table.organisation_id.comment, '__getitem__'):
    table.organisation_id.comment[0].vars = dict(parent="vehicle")
```

**Safety guarantees:**
1. `comment` is not None
2. `comment` supports indexing (`__getitem__` attribute)
3. Only then modify `comment[0].vars`

**Behavior:**
- **If comment exists and is indexable:** Sets vars as intended
- **If comment is None/empty:** Silently skips (safe degradation)
- **Vehicle registration:** Works without crashing

## Impact for Disaster Response
- ✅ Unblocks vehicle registration workflow
- ✅ Enables tracking ambulances, rescue vehicles, supply trucks
- ✅ Critical for coordinating tsunami/earthquake/pandemic relief

## Testing
**Manual testing needed:**
- Test vehicle creation with default template
- Verify no IndexError crash
- Confirm organisation_id field works correctly
- Test with various template configurations

**Expected outcome:**
Vehicle registration completes successfully without IndexError.

## Related
This pattern (unsafe `comment[0]` access) appears only in this file in the controllers directory. Other files use safe conditional checks before accessing comment properties.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>