### PR TITLE
Fix PDF table LayoutError by falling back to auto row heights

### DIFF
--- a/modules/core/formats/pdf.py
+++ b/modules/core/formats/pdf.py
@@ -56,7 +56,8 @@ try:
                                    PageTemplate, \
                                    Paragraph, \
                                    Spacer, \
-                                   Table
+                                   Table, \
+                                   LayoutError
     from reportlab.platypus.frames import Frame
     reportLabImported = True
 except ImportError:
@@ -1453,15 +1454,27 @@ class PDFTable:
             style = self.table_style(start_row, num_rows, len(col_widths) - 1)
             (part, style) = main_doc.addCellStyling(part, style)
 
-            p = Table(part,
-                      repeatRows = 1,
-                      style = style,
-                      hAlign = "LEFT",
-                      colWidths = col_widths,
-                      rowHeights = row_heights,
-                      emptyTableAction = "indicate",
-                      )
-            tables.append(p)
+            try:
+                p = Table(part,
+                          repeatRows=1,
+                          style= style,
+                          hAlign= "LEFT",
+                          colWidths= col_widths,
+                          rowHeights= row_heights,
+                          emptyTableAction= "indicate",
+                          )
+                tables.append(p)
+            except LayoutError:
+                # Fallback: let ReportLab auto-calculate row heights
+                p = Table(part,
+                          repeatRows= 1,
+                          style= style,
+                          hAlign= "LEFT",
+                          colWidths= col_widths,
+                          emptyTableAction= "indicate",
+                          )
+                tables.append(p)
+
 
             # Add a page break, except for the last part
             next_part = current_part + 1


### PR DESCRIPTION
### Problem
PDF generation fails with a ReportLab LayoutError when table row heights overflow the available page space.

### Solution
This PR wraps the Table creation in a try/except block.  
If a LayoutError occurs, it falls back to letting ReportLab auto-calculate row heights instead of crashing.

### Impact
- Prevents PDF export from failing
- Preserves existing layout logic when possible
- Adds a safe fallback for edge cases