### PR TITLE
Add impact analysis for includes.py module for assignment 2

### DIFF
--- a/assignment2/includes_impact_analysis.md
+++ b/assignment2/includes_impact_analysis.md
@@ -1,0 +1,496 @@
+# Impact Analysis: CSS/JS Include System (includes.py)
+
+## 1. Addressed Component/Module
+
+### Overview
+The **CSS/JS Include System** (`modules/core/tools/includes.py`) is a core utility module responsible for managing the dynamic loading of stylesheets and JavaScript libraries throughout the Sahana-Eden application.
+
+### Key Responsibilities
+- **Dynamic Asset Loading**: Generates HTML markup for including CSS and JavaScript files based on application configuration
+- **Theme Integration**: Reads theme-specific CSS configurations from template directories
+- **Debug Mode Support**: Provides separate loading paths for minified vs. debug versions of scripts
+- **Third-Party Library Integration**: Manages inclusion of external libraries (DataTables, ExtJS, Underscore.js)
+- **CDN Fallback Logic**: Supports both local and CDN-hosted asset delivery based on deployment settings
+- **Configuration-Driven Loading**: Uses `.cfg` files to determine which assets to load dynamically
+
+### Importance and Impact
+This module is foundational to the application's **UI rendering pipeline**. Every page served by Sahana-Eden depends on the correct initialization of CSS and JavaScript assets. Any failure in this system directly impacts:
+- Theme rendering and visual consistency
+- Interactive widget functionality (DataTables, ExtJS components)
+- Client-side template processing
+- User experience and page responsiveness
+
+The module acts as a **bridge between the web framework (Web2py) and the frontend asset ecosystem**, making it critical for maintaining backward compatibility and system stability.
+
+---
+
+## 2. Graph: Call Graph
+
+### High-Level Function Relationships
+
+```
+                           ┌────────────────────────────────────┐
+                           │    includes.py (CSS/JS Module)     │
+                           └────────────────┬───────────────────┘
+                                            │
+                ┌───────────────────────────┼───────────────────────────────┐
+                │                           │                               │
+                ▼                           ▼                               ▼
+        ┌──────────────────┐        ┌──────────────────┐        ┌─────────────────────┐
+        │ include_debug_   │        │ include_debug_   │        │ include_datatable_  │
+        │      css()       │        │      js()        │        │       js()          │
+        └────────┬─────────┘        └────────┬─────────┘        └──────────┬──────────┘
+                 │                           │                            │
+                 ▼                           ▼                            ▼
+        ┌──────────────────────┐   ┌──────────────────────┐   ┌─────────────────────┐
+        │ Reads theme config   │   │ Uses mergejsmf to    │   │ Reads s3.datatable_ │
+        │ from css.cfg file    │   │ resolve .js files    │   │ opts; handles debug │
+        └──────────────────────┘   └──────────────────────┘   │ vs minified selec.  │
+                                                              └─────────────────────┘
+                │                           │
+                ▼                           ▼                                 │
+        ┌──────────────────────┐   ┌──────────────────────┐                   ▼
+        │ Returns XML with     │   │ Returns XML with     │        ┌─────────────────────┐
+        │ <link> tags          │   │ <script> tags        │        │ Appends to          │
+        └──────────────────────┘   └──────────────────────┘        │ s3.scripts list     │
+                                                                   └─────────────────────┘
+
+        ┌─────────────────────────────────────────────────────────────────┐
+        │                           │                                     │
+        ▼                           ▼                                     ▼
+    ┌────────────────────┐     ┌──────────────────┐             ┌────────────────────┐
+    │  include_ext_js()  │     │ include_underscore│             │ External           │
+    │                    │     │      _js()        │             │ Dependencies:      │
+    │ Handles ExtJS lib, │     │                   │             │ • current.request  │
+    │ adapters, themes,  │     │ CDN or local      │             │ • current.response │
+    │ locale support     │     │ Underscore lib    │             │ • mergejsmf        │
+    └────────┬───────────┘     └────────┬──────────┘             │ • URL()            │
+             │                          │                        │ • settings         │
+             ▼                          ▼                        └────────────────────┘
+    ┌────────────────────┐     ┌──────────────────┐
+    │ Appends to         │     │ Appends to       │
+    │ s3.scripts &       │     │ s3.scripts with  │
+    │ s3.jquery_ready    │     │ duplicate check  │
+    └────────────────────┘     └──────────────────┘
+```
+
+### Detailed Function-Level Call Graph
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     include_debug_css() EXECUTION FLOW                       │
+└─────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼ Get current.request
+    ┌─────────────────────────────┐
+    │ Extract request.folder      │
+    │ Extract request.application │
+    └────────────┬────────────────┘
+                 │
+                 ▼ Get theme location
+    ┌─────────────────────────────────────┐
+    │ current.response.s3.theme_config    │
+    └────────────┬────────────────────────┘
+                 │
+                 ▼ Construct config file path
+    ┌──────────────────────────────────────────────────────────┐
+    │ {request.folder}/modules/templates/{theme}/css.cfg       │
+    └────────────┬───────────────────────────────────────────┘
+                 │
+                 ▼ Check file exists
+    ┌──────────────────────────────────────┐
+    │ os.path.isfile(filename)             │
+    │ If missing → HTTP 500 error          │
+    └────────────┬───────────────────────┘
+                 │
+                 ▼ Read CSS filenames
+    ┌────────────────────────────────────────┐
+    │ Parse lines from css.cfg (skip #)      │
+    │ Collect CSS filenames into list        │
+    └────────────┬───────────────────────────┘
+                 │
+                 ▼ Generate <link> tags
+    ┌─────────────────────────────────────────────────────────┐
+    │ For each CSS: <link href="/app/static/styles/X.css"...> │
+    └────────────┬────────────────────────────────────────────┘
+                 │
+                 ▼
+        ┌──────────────────┐
+        │ Return XML()     │
+        │ (markup)         │
+        └──────────────────┘
+
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                     include_debug_js() EXECUTION FLOW                        │
+└─────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼ Get current.request
+    ┌──────────────────────────────────┐
+    │ Extract request.folder           │
+    │ Extract request.application      │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼ Setup config_dict with paths
+    ┌──────────────────────────────────────┐
+    │ "." → scripts_dir                    │
+    │ "ui" → scripts_dir                   │
+    │ "web2py" → scripts_dir               │
+    │ "S3" → scripts_dir                   │
+    └────────────┬───────────────────────┘
+                 │
+                 ▼ Import mergejsmf
+    ┌──────────────────────────────────────┐
+    │ import mergejsmf (library)           │
+    └────────────┬───────────────────────┘
+                 │
+                 ▼ Call mergejsmf.getFiles()
+    ┌──────────────────────────────────────────────┐
+    │ Parse /static/scripts/tools/sahana.js.cfg    │
+    │ Resolve all JS file dependencies             │
+    │ Return [status, files_list]                  │
+    └────────────┬───────────────────────────────┘
+                 │
+                 ▼ Extract files list
+    ┌──────────────────────────────────────┐
+    │ files = mergejsmf.getFiles(...)[1]   │
+    │ (second element of return tuple)     │
+    └────────────┬───────────────────────┘
+                 │
+                 ▼ Generate <script> tags
+    ┌─────────────────────────────────────────────────┐
+    │ For each JS: <script src="/app/static/..."> │
+    └────────────┬──────────────────────────────────┘
+                 │
+                 ▼
+        ┌──────────────────┐
+        │ Return XML()     │
+        │ (markup)         │
+        └──────────────────┘
+
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                   include_datatable_js() EXECUTION FLOW                      │
+└─────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼ Access current.response.s3
+    ┌─────────────────────────┐
+    │ Get s3.scripts list     │
+    │ Get s3.datatable_opts   │
+    └────────────┬────────────┘
+                 │
+                 ▼ Determine debug vs minified
+    ┌──────────────────────────────────┐
+    │ Check s3.debug flag              │
+    │ if True: use .js files           │
+    │ if False: use .min.js files      │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼ Append base DataTables script
+    ┌──────────────────────────────────────────┐
+    │ s3.scripts.append(jquery.dataTables.js)  │
+    └────────────┬─────────────────────────────┘
+                 │
+                 ▼ Conditional features (check datatable_opts)
+    ┌──────────────────────────────────────────┐
+    │ if responsive: append responsive script  │
+    │ if variable_columns: append columns JS   │
+    └────────────┬─────────────────────────────┘
+                 │
+                 ▼ Append s3.ui.datatable script
+    ┌──────────────────────────────────────────┐
+    │ s3.scripts.append(s3.ui.datatable.js)    │
+    └──────────────────────────────────────────┘
+
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                      include_ext_js() EXECUTION FLOW                         │
+└─────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼ Check if ExtJS already included
+    ┌──────────────────────────────────┐
+    │ if s3.ext_included: return       │
+    │ (prevent duplicate inclusion)    │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼ Get deployment settings
+    ┌──────────────────────────────────┐
+    │ xtheme = get_base_xtheme()       │
+    │ (theme CSS selection)            │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼ Determine CDN vs local PATH
+    ┌──────────────────────────────────┐
+    │ if s3.cdn: use CDN path          │
+    │ else: use local static path      │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼ Select debug vs minified
+    ┌──────────────────────────────────┐
+    │ if s3.debug: use -debug.js files │
+    │ else: use minified files         │
+    └────────────┬─────────────────────┘
+                 │
+        ┌────────┴────────┐
+        ▼                 ▼
+    ┌─────────────┐  ┌──────────────────────┐
+    │ Append      │  │ Check for locale     │
+    │ adapter &   │  │ file (ext-lang-*.js) │
+    │ main JS     │  │ Append if exists     │
+    └────────┬────┘  └──────────┬───────────┘
+             │                   │
+             └────────┬──────────┘
+                      ▼
+    ┌──────────────────────────────────┐
+    │ Inject jQuery ready call         │
+    │ (to insert theme CSS correctly)  │
+    │ s3.jquery_ready.append(...)      │
+    └────────────┬─────────────────────┘
+                 │
+                 ▼
+    ┌──────────────────────────────────┐
+    │ Set s3.ext_included = True       │
+    │ (mark as done)                   │
+    └──────────────────────────────────┘
+
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                 include_underscore_js() EXECUTION FLOW                       │
+└─────────────────────────────────────────────────────────────────────────────┘
+        │
+        ▼ Access current.response.s3
+    ┌──────────────────────┐
+    │ Get s3.debug flag    │
+    │ Get s3.cdn flag      │
+    │ Get s3.scripts list  │
+    └────────────┬─────────┘
+                 │
+                 ▼ Determine CDN vs local + debug vs minified
+    ┌──────────────────────────────────────────┐
+    │ if s3.cdn:                               │
+    │   if debug: use CDN .js file             │
+    │   else: use CDN .min.js file             │
+    │ else:                                    │
+    │   if debug: use local underscore.js      │
+    │   else: use local underscore-min.js      │
+    └────────────┬─────────────────────────────┘
+                 │
+                 ▼ Generate script URL
+    ┌──────────────────────────────────────────┐
+    │ Call URL(c="static", f="scripts/...")    │
+    │ OR use direct CDN URL                    │
+    └────────────┬─────────────────────────────┘
+                 │
+                 ▼ Check if already in scripts
+    ┌──────────────────────────────────────────┐
+    │ if script not in s3.scripts:             │
+    │   s3.scripts.append(script)              │
+    │ (prevent duplicate inclusion)            │
+    └──────────────────────────────────────────┘
+```
+
+---
+
+## 3. Dependency Analysis
+
+### Internal Dependencies
+
+#### Function Interdependencies
+- **include_debug_css()** and **include_debug_js()** are independent top-level functions; both read configuration files but operate on separate asset types
+- **include_datatable_js()** directly modifies `s3.scripts` list; doesn't call other include functions but works within the same namespace
+- **include_ext_js()** performs its own CSS/JS injection via `s3.scripts` and `s3.jquery_ready` lists
+- **include_underscore_js()** conditionally appends to `s3.scripts` with duplicate-checking logic
+
+#### Shared State Management
+All functions access and modify `current.response.s3`, which serves as the central repository for:
+- `s3.scripts`: List of script URLs to load
+- `s3.stylesheets` / `s3.external_stylesheets`: CSS link tracking
+- `s3.debug`: Debug mode flag determining asset selection
+- `s3.cdn`: CDN availability flag
+- `s3.datatable_opts`: DataTables configuration options
+- `s3.language`: Current language setting for locale-specific files
+- `s3.ext_included`: Flag preventing duplicate ExtJS inclusion
+- `s3.jquery_ready`: jQuery initialization queue
+
+### External Dependencies
+
+#### Configuration Objects
+- **`current.request`**: Provides `request.folder` (base path), `request.application` (app name)
+- **`current.response`**: Provides `s3` object for state management and theme configuration
+- **`current.deployment_settings`**: Provides `get_base_xtheme()` for theme selection and CDN availability checks
+
+#### File System Dependencies
+- Theme CSS configuration: `/modules/templates/<theme>/css.cfg`
+- Sahana script manifest: `/static/scripts/tools/sahana.js.cfg`
+- ExtJS locale files: `/static/scripts/ext/src/locale/<lang>.js`
+- ExtJS resources and theme files
+
+#### Third-Party Library Dependencies
+- **`mergejsmf`**: Parses JavaScript manifest files and resolves file lists
+- **`URL()`**: Generates relative URLs for non-CDN hosted scripts
+- **`XML()`**: Wraps HTML markup to prevent escaping in response
+
+#### Environment Influences
+1. **Debug Mode (`s3.debug`)**:
+   - When `True`: Loads unminified, debug versions of scripts (better for development)
+   - When `False`: Loads production minified versions (smaller file sizes)
+
+2. **CDN Setting (`s3.cdn`)**:
+   - When `True`: Uses CloudFlare CDN for external libraries (faster for public internet sites)
+   - When `False`: Serves from local static directories (better for private/offline deployments)
+
+3. **Theme Configuration**:
+   - Read from `css.cfg` files in `/modules/templates/<theme>/`
+   - Determines which stylesheets to include per theme
+
+4. **Deployment Settings**:
+   - ExtJS theme selection via `get_base_xtheme()`
+   - Influences responsive DataTables inclusion
+
+---
+
+## 4. Impact or Insights
+
+### System Dependents
+The CSS/JS Include System is relied upon by:
+- **View/Template Layer**: All `.html` views expect these functions to inject necessary assets
+- **Widget Framework**: DataTables, ExtJS, and other UI widgets assume their scripts are loaded
+- **Theme System**: Theme rendering depends on CSS being injected in correct order
+- **Layout Controllers**: Base layout controllers call these functions during page initialization
+- **Application Initialization**: Early bootstrap phase depends on core library loading
+
+### Impact of Module Changes
+
+#### UI Rendering Failures
+- Removing a CSS include function breaks theme styling
+- Modifying script paths breaks widget functionality (DataTables won't render, ExtJS maps won't load)
+- Changing debug/minified logic affects development workflows
+
+#### Backward Compatibility Requirements
+This module **must maintain strict backward compatibility** because:
+1. **View Templates** across the entire codebase depend on these functions existing
+2. **Third-party integrations** may rely on specific script loading order
+3. **Custom themes** depend on `include_debug_css()` reading their `.cfg` files correctly
+4. **JavaScript initialization** code in views expects certain libraries to be available
+
+#### Maintainability Improvements from Assignment 1
+If Assignment 1 involved refactoring related code:
+- **Centralized configuration**: Reduces scattered asset references
+- **Cleaner path construction**: Makes the dependency chain more obvious
+- **Improved error handling**: Makes failures more diagnosable
+- **Better code organization**: Reduces cognitive load when debugging asset loading issues
+
+### Why This Module Is Critical
+The CSS/JS Include System is a **thin critical layer** that interfaces between:
+- Web framework infrastructure (Web2py request/response)
+- File system (configuration and asset directories)
+- Frontend ecosystem (CSS/JS libraries and frameworks)
+
+Any bug in this layer cascades to **100% of application pages**, making it one of the highest-impact components to test thoroughly.
+
+---
+
+## 5. Ripple Effects
+
+### Feature Breakdown Dependencies
+
+#### Theme Rendering
+- **Direct Dependency**: `include_debug_css()`
+- **Impact**: If CSS loading fails:
+  - Page layout breaks completely
+  - Colors, fonts, and spacing are missing
+  - Responsive design ceases to function
+  - Accessibility features (contrast, font sizes) are lost
+- **Downstream Effects**: All pages become visually unusable
+
+#### DataTables Widgets
+- **Direct Dependency**: `include_datatable_js()`
+- **Configuration Options**: Responsive design, variable columns
+- **Impact**: If DataTables scripts fail:
+  - Tables render as plain HTML (no sorting, filtering, pagination)
+  - Responsive tables don't adapt to mobile screens
+  - Dynamic column selection breaks
+  - Search functionality unavailable
+- **Downstream Effects**: Data list views, reporting interfaces, dashboards become non-interactive
+
+#### ExtJS Map Components
+- **Direct Dependency**: `include_ext_js()`, ExtJS adapter
+- **Conditional Components**: Theme CSS, locale files
+- **Impact**: If ExtJS loading fails:
+  - Map widgets don't initialize
+  - Geographic data visualization breaks
+  - Spatial analysis features become inaccessible
+  - GIS module functionality collapses
+- **Downstream Effects**: All location-based features (asset tracking, incident mapping, resource distribution)
+
+#### Underscore.js-Based Widgets
+- **Direct Dependency**: `include_underscore_js()`
+- **Use Case**: Template compilation, data manipulation in views
+- **Impact**: If Underscore.js fails:
+  - Template rendering widgets break
+  - Grouped option widgets malfunction
+  - Client-side data transformations fail
+  - Some interactive UI components fail to initialize
+- **Downstream Effects**: Complex form widgets, grouped layouts, dynamic content generation
+
+### Cascading Failure Scenarios
+
+```
+Script Loading Failure (any function)
+    ↓
+Asset Not Available in Browser
+    ↓
+JavaScript Runtime Error (library undefined)
+    ↓
+Widget Initialization Fails
+    ↓
+Feature Becomes Non-Functional
+    ↓
+User Cannot Complete Tasks
+    ↓
+Application Unusable
+```
+
+### Cross-Module Dependencies
+- **Controllers**: Call include functions indirectly via base layout
+- **Models**: Don't depend directly, but their data won't display without CSS/JS
+- **Views**: Hard-depend on asset availability for form rendering
+- **Modules**: Plugins/custom modules assume core libraries are available
+
+---
+
+## 6. Summary
+
+### Key Insights
+
+#### Module Purpose
+The CSS/JS Include System (`includes.py`) serves as the **centralized asset pipeline** for Sahana-Eden, translating configuration-driven decisions (theme selection, debug mode, CDN availability) into concrete HTML markup that loads necessary frontend libraries.
+
+#### Maintainability Considerations
+1. **Configuration-Driven Architecture**: Using `.cfg` files reduces hardcoded dependencies
+2. **Conditional Loading**: Debug/minified and CDN/local switching make the system adaptable
+3. **Single Responsibility**: Each function handles one asset type (CSS, DataTables, ExtJS, Underscore)
+4. **Centralized State**: Using `current.response.s3` as state repository keeps logic cohesive
+
+#### Stability Requirements
+- **Zero Tolerance for Bugs**: Any failure affects 100% of page load
+- **Backward Compatibility**: Must preserve function signatures and behavior
+- **Configuration Integrity**: `.cfg` files must be correct and accessible
+- **Path Resolution**: Correct path construction is critical across different deployment environments
+
+#### Impact of Assignment 1 Refactoring
+If Assignment 1 improved related code:
+- **Reduced Complexity**: Fewer interdependencies make this module easier to understand
+- **Better Error Messages**: Improved diagnostics help identify configuration issues faster
+- **Cleaner Interfaces**: Well-defined function signatures reduce integration bugs
+- **Enhanced Testability**: Modular design allows unit testing of each include function independently
+
+### Critical Dependencies to Monitor
+- **File System Access**: Theme `.cfg` files must exist and be readable
+- **Import Success**: `mergejsmf` module must be available for `include_debug_js()`
+- **Runtime State**: `current` object (request, response, deployment_settings) must be properly initialized
+- **Deployment Environment**: CDN availability, theme selection, and debug mode must align with actual deployment
+
+### Conclusion
+The CSS/JS Include System is a **foundational component** that enables the entire application to function. Its apparently simple role—generating HTML markup—masks critical importance: it serves as the single point of control for frontend asset delivery across the entire platform. Maintaining code quality, backward compatibility, and test coverage in this module is essential for application stability and user experience.
+


### PR DESCRIPTION
This pull request contains my Assignment 2 submission for the Sahana-Eden SME project.

I conducted an impact analysis on the CSS/JS Include System located in 
`modules/core/tools/includes.py`. The analysis examines how this core component 
manages stylesheet and JavaScript loading across the application, including 
dependencies between its five main functions (include_debug_css, include_debug_js, 
include_datatable_js, include_ext_js, include_underscore_js) and external 
dependencies.

Included in this PR:
- **includes_impact_analysis.md**: Comprehensive analysis including:
  1. Component overview and system importance
  2. High-level and detailed call graphs (ASCII diagrams)
  3. Internal and external dependency analysis
  4. Impact assessment on UI rendering and system stability
  5. Ripple effects analysis for critical features
  6. Maintainability summary

No functional code was modified. This PR is purely documentation-based 
for Assignment 2 requirements.