### PR TITLE
Docs for setting up a development environment with Docker added

### DIFF
--- a/docs/source/_static/css/treeview.css
+++ b/docs/source/_static/css/treeview.css
@@ -1,0 +1,3 @@
+.treeview li {
+	list-style: none !important;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,8 @@
 #
 import os
 import sys
+from sphinx_treeview.decorator import DecoratorType
+
 sys.path.insert(0, os.path.abspath('../../../web2py'))
 sys.path.insert(0, os.path.abspath('../../modules'))
 
@@ -28,7 +30,7 @@ author = 'Sahana Eden Team'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx_treeview']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -50,5 +52,13 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = ['css/treeview.css']
 
 autoclass_content = "both"
+
+stv_decorators = [
+	DecoratorType(
+		name="custom",
+		icons = []
+	)
+]

--- a/docs/source/dev/advanced.rst
+++ b/docs/source/dev/advanced.rst
@@ -16,3 +16,140 @@ Models in templates
 
 Re-routing controllers
 ----------------------
+
+Development with Docker container
+---------------------------------
+
+If you want to develop on Windows (or Mac) you can use a Docker container
+with Debian.
+
+.. note::
+
+   It is even possible to build and run your container inside WSL. In this case 
+   please make sure that you have the **Docker Desktop App** for Windows 
+   running beside your WSL docker service! Otherwise the port forwarding will not work 
+   and your web2py project will not be available via localhost.
+
+On your machine create a project folder `eden-dev`. Create the following two
+files in it:
+
+.. code-block:: dockerfile
+  :caption: Dockerfile
+ 
+	FROM debian:13
+
+	ENV DEBIAN_FRONTEND=noninteractive
+	ENV LANG=C.UTF-8
+
+	RUN apt-get update && apt-get install -y \
+			python3 \
+			python3-pip \
+			git \
+			nano \
+			vim \
+			curl \
+			wget \
+			build-essential \
+			libxml2 \
+			libxslt1.1 \
+			libgeos-c1v5 \
+			libpq5 \
+			libjpeg62-turbo \
+			zlib1g \
+			libfreetype6 \
+			&& rm -rf /var/lib/apt/lists/*
+
+	RUN pip3 install --break-system-packages --only-binary=:all: \
+			lxml \
+			python-dateutil \
+			pyparsing \
+			requests \
+			xlrd \
+			xlwt \
+			openpyxl \
+			reportlab \
+			shapely \
+			geopy \
+			qrcode \
+			docx-mailmerge \
+			psycopg2-binary \
+			sphinx \
+			sphinx-rtd-theme
+
+	# Workspace
+	WORKDIR /workspace
+
+	RUN git clone https://github.com/web2py/web2py.git && \
+			cd web2py && \
+			git reset --hard  d6dcbef && \
+			git submodule update --init --recursive
+
+	# Generating self-signed certificate
+	RUN openssl req -x509 -newkey rsa:4096 \
+		-keyout /workspace/key.pem -out /workspace/cert.pem -days 365 -nodes \
+		-subj "/C=US/ST=State/L=City/O=Organization/OU=Department/CN=localhost.local"
+
+	EXPOSE 8000
+
+.. code-block:: yaml
+	:caption: docker-compose.yml
+
+	services:
+		eden:
+			build: .
+			container_name: eden-dev
+			volumes:
+				- ./eden:/workspace/eden
+			ports:
+				- "8000:8000"
+				- "5432:5432"
+			tty: true
+			stdin_open: true
+
+Afterwards clone the Eden repo into your folder:
+
+.. code-block:: console
+
+	git clone https://github.com/sahana/eden.git
+
+Your folder should now look like this:
+
+.. treeview::
+   - :dir:`folder` Your folder
+      - :dir:`folder` eden
+      - :dir:`file` Dockerfile
+      - :dir:`file` docker-compose.yml
+
+Now from inside of your folder you can build your image and your container:
+
+.. code-block:: console
+
+   docker-compose build --no-cache
+   docker-compose up -d
+
+The container is now running. Next time to start your container you only
+have to type:
+
+.. code-block:: console
+
+   docker start eden-dev
+
+You can enter your running container with:
+
+.. code-block:: console
+
+   docker exec -it eden-dev bash
+
+The folder `eden` from your project folder is mounted on your container to 
+`/workspace/eden`. The changes you make inside the container to the files and folders
+here will also change the files in your local eden folder and the other way around. 
+This way you can work locally with the IDE of your choice on the Eden project.
+
+From here you can follow the main documentation for configuring Eden as a web2py application as described :ref:`here <entrance-docker-setup>`.
+
+.. note::
+
+   Eden is available via browser on http://localhost:18000 if you're using this 
+   container setup to keep port 8000 available to other projects! Keep it in mind 
+   when you follow the rest of the configuration documentation.
+

--- a/docs/source/dev/setup.rst
+++ b/docs/source/dev/setup.rst
@@ -13,6 +13,9 @@ application development on your computer.
    general guideline, but commands may be different, and additional installation
    steps could be required.
 
+   You can use a docker container for development and testing. This is described
+   here.
+
 .. note::
 
    This guide further assumes that you have *Python* (version 3.9 or later)
@@ -86,6 +89,8 @@ To install Eden, clone it directly from GitHub:
 .. tip::
    You can of course choose any other target location than *~/eden* for
    the clone - just remember to use the correct path in subsequent commands.
+
+.. _entrance-docker-setup:
 
 Configure Eden as a web2py application by adding a symbolic link
 to the *eden* directory under *web2py/applications*:

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-rtd-theme
+sphinx-treeview


### PR DESCRIPTION
A section how to set up a docker environment to develop Eden on Windows or Mac has been added to the documentation. It contains a Dockerfile and a docker-compose.yml to easily build a Debian container.