### PR TITLE
Fix AttributeError when auth.user is None in filter rendering

### DIFF
--- a/modules/core/filters/base.py
+++ b/modules/core/filters/base.py
@@ -759,7 +759,8 @@ class FilterForm:
 
         # Current user
         auth = current.auth
-        pe_id = auth.user.pe_id if auth.s3_logged_in() else None
+        user = auth.user
+        pe_id = user.pe_id if user and auth.s3_logged_in() else None
         if not pe_id:
             return None
 


### PR DESCRIPTION
Fixes a potential AttributeError in filter rendering when auth.user is None.

Previously:
    pe_id = auth.user.pe_id if auth.s3_logged_in() else None

This could raise an AttributeError if auth.user is None.

Now:
    user = auth.user
    pe_id = user.pe_id if user and auth.s3_logged_in() else None

This ensures safe access and prevents crashes when no user is logged in.