### PR TITLE
Fix AttributeError when auth.user is None in filter rendering

### DIFF
--- a/modules/core/filters/base.py
+++ b/modules/core/filters/base.py
@@ -759,7 +759,8 @@ class FilterForm:
 
         # Current user
         auth = current.auth
-        pe_id = auth.user.pe_id if auth.s3_logged_in() else None
+        user = auth.user
+        pe_id = user.pe_id if user and auth.s3_logged_in() else None
         if not pe_id:
             return None
 


### PR DESCRIPTION
Fixes #76

### Summary

Adds a null-safety check when accessing `auth.user.pe_id` during filter rendering.

### Problem

In certain edge cases (e.g. anonymous access or misconfigured authentication), `auth.user` can be `None`.
This leads to:

AttributeError: 'NoneType' object has no attribute 'pe_id'

### Solution

Added a safe check before accessing `pe_id`:

```python
user = auth.user
pe_id = user.pe_id if user and auth.s3_logged_in() else None
```

### Notes

While this may not occur in standard authenticated flows, this change improves robustness and prevents crashes in edge cases.
