### PR TITLE
Fix docs for docker

### DIFF
--- a/docs/source/dev/advanced.rst
+++ b/docs/source/dev/advanced.rst
@@ -104,8 +104,7 @@ files in it:
 			volumes:
 				- ./eden:/workspace/eden
 			ports:
-				- "8000:8000"
-				- "5432:5432"
+				- "18000:8000"
 			tty: true
 			stdin_open: true
 

--- a/docs/source/dev/advanced.rst
+++ b/docs/source/dev/advanced.rst
@@ -52,6 +52,7 @@ files in it:
 			curl \
 			wget \
 			build-essential \
+			openssl \ 
 			libxml2 \
 			libxslt1.1 \
 			libgeos-c1v5 \

--- a/docs/source/dev/advanced.rst
+++ b/docs/source/dev/advanced.rst
@@ -17,6 +17,8 @@ Models in templates
 Re-routing controllers
 ----------------------
 
+ .. _docker:
+ 
 Development with Docker container
 ---------------------------------
 

--- a/docs/source/dev/advanced.rst
+++ b/docs/source/dev/advanced.rst
@@ -18,7 +18,7 @@ Re-routing controllers
 ----------------------
 
  .. _docker:
- 
+
 Development with Docker container
 ---------------------------------
 
@@ -116,11 +116,12 @@ Afterwards clone the Eden repo into your folder:
 
 Your folder should now look like this:
 
-.. treeview::
-   - :dir:`folder` Your folder
-      - :dir:`folder` eden
-      - :dir:`file` Dockerfile
-      - :dir:`file` docker-compose.yml
+.. code-block:: text
+
+   Your folder/                 
+   ├── eden/	# The eden repository must be cloned here
+   ├── Dockerfile
+   └── docker-compose.yml
 
 Now from inside of your folder you can build your image and your container:
 

--- a/docs/source/dev/setup.rst
+++ b/docs/source/dev/setup.rst
@@ -14,7 +14,7 @@ application development on your computer.
    steps could be required.
 
    You can use a docker container for development and testing. This is described
-   here.
+   :ref:`here <docker>`.
 
 .. note::
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -1,2 +1,1 @@
 sphinx-rtd-theme
-sphinx-treeview


### PR DESCRIPTION
**Summary**

This pull request fixes an issue with the documentation build failing when executed by a non-root user and improves documentation navigation by correcting a missing link.

**Changes**

1. Fix documentation build failure (non-root users)

The original documentation build fails when run as a non-root user due to an issue with the sphinx-treeview dependency. The extension appears to attempt writing to the site-packages directory, which is not permitted without elevated privileges.

To resolve this, the sphinx-treeview dependency has been removed. The documentation builds successfully without it, using the standard Sphinx theme and features.

2. Fix missing documentation link

The "Setting up for Development" page references the "Development with Docker container" documentation, but no link was provided.

This has been fixed by adding the appropriate link, improving navigation and usability for developers.