### PR TITLE
Removed left over CSS of deleted sphinx-treeview package

### DIFF
--- a/docs/source/_static/css/treeview.css
+++ b/docs/source/_static/css/treeview.css
@@ -1,3 +1,0 @@
-.treeview li {
-	list-style: none !important;
-}


### PR DESCRIPTION
The sphinx-treeview package for the docs had been removed in [#80](https://github.com/sahana/eden/pull/80) because of a package related bug. Only the CSS remained. Now it has been removed as well.