### PR TITLE
Set meaningful worksheet title for pivot table XLSX exports

### DIFF
--- a/modules/core/formats/xlsx.py
+++ b/modules/core/formats/xlsx.py
@@ -633,6 +633,9 @@ class XLSXPivotTableWriter:
             book.add_named_style(style)
 
         sheet = book.active
+        sheet_title = fact_label or title or s3_str(T("Report"))
+        sheet_title = re.sub(r'[:\\/?*\[\]]', "", sheet_title)
+        sheet.title = sheet_title[:31]
         write = self.write
 
         # Write header


### PR DESCRIPTION
Overview
This PR sets a meaningful worksheet title for pivot table XLSX exports instead of using the default "Sheet" name.

Changes
Use the aggregated fact label as worksheet title when available
Fall back to the report title if needed
Fall back to "Report" if neither is available
Sanitize worksheet titles to remove invalid Excel characters
Truncate worksheet titles to Excel's 31-character limit
Example
Before:

Sheet
After:

Number of Shipments
Sent Quantity
Number of Items