### PR TITLE
fix(inv): warehouse type global uniqueness cleanup (#45)

### DIFF
--- a/modules/s3db/inv.py
+++ b/modules/s3db/inv.py
@@ -145,8 +145,6 @@ class InvWarehouseModel(DataModel):
         # ---------------------------------------------------------------------
         # Warehouse Types
         #
-        # org_dependent_wh_types = settings.get_inv_org_dependent_warehouse_types()
-
         tablename = "inv_warehouse_type"
         define_table(tablename,
                      Field("name", length=128, notnull=True,
@@ -182,8 +180,6 @@ class InvWarehouseModel(DataModel):
                                           requires = IS_EMPTY_OR(
                                                         IS_ONE_OF(db, "inv_warehouse_type.id",
                                                                   represent,
-                                                                  #filterby="organisation_id",
-                                                                  #filter_opts=filter_opts if org_dependent_wh_types else None,
                                                                   sort=True
                                                                   )),
                                           sortby = "name",
@@ -197,16 +193,8 @@ class InvWarehouseModel(DataModel):
 
         configure(tablename,
                   deduplicate = S3Duplicate(primary = ("name",),
-                                            # secondary = ("organisation_id",) if org_dependent_wh_types else None,
                                             ),
                   )
-
-        # Tags as component of Warehouse Types
-        #self.add_components(tablename,
-        #                    inv_warehouse_type_tag={"name": "tag",
-        #                                            "joinby": "warehouse_type_id",
-        #                                            }
-        #                    )
 
         # ---------------------------------------------------------------------
         # Warehouses

--- a/static/formats/s3csv/inv/warehouse_type.xsl
+++ b/static/formats/s3csv/inv/warehouse_type.xsl
@@ -8,7 +8,6 @@
          CSV column...........Format..........Content
 
          Name.................string..........Warehouse Type Name
-         Organisation.........string..........Organisation Name
          Comments.............string..........Comments
 
          @ToDo if-required:
@@ -21,18 +20,8 @@
     <xsl:include href="../../xml/commons.xsl"/>
 
     <!-- ****************************************************************** -->
-    <!-- Indexes for faster processing -->
-    <xsl:key name="orgs" match="row" use="col[@field='Organisation']"/>
-
-    <!-- ****************************************************************** -->
     <xsl:template match="/">
         <s3xml>
-            <!-- Organisations -->
-            <xsl:for-each select="//row[generate-id(.)=generate-id(key('orgs',
-                                                                       col[@field='Organisation'])[1])]">
-                <xsl:call-template name="Organisation"/>
-            </xsl:for-each>
-
             <xsl:apply-templates select="./table/row"/>
         </s3xml>
     </xsl:template>
@@ -40,20 +29,9 @@
     <!-- ****************************************************************** -->
 
     <xsl:template match="row">
-        <xsl:variable name="OrgName" select="col[@field='Organisation']/text()"/>
-
         <resource name="inv_warehouse_type">
             <data field="name"><xsl:value-of select="col[@field='Name']"/></data>
             <data field="comments"><xsl:value-of select="col[@field='Comments']"/></data>
-
-            <!-- Link to Organisation to filter lookup lists -->
-            <xsl:if test="$OrgName!=''">
-                <reference field="organisation_id" resource="org_organisation">
-                    <xsl:attribute name="tuid">
-                        <xsl:value-of select="$OrgName"/>
-                    </xsl:attribute>
-                </reference>
-            </xsl:if>
 
             <!-- Arbitrary Tags
             <xsl:for-each select="col[starts-with(@field, 'KV')]">


### PR DESCRIPTION
## Summary
Removes stale org-specific warehouse type handling; aligns `warehouse_type.xsl` with global name uniqueness (#45).

**Note:** @NA-V10 is assigned on #45 — happy to close this PR if they have an overlapping patch.

## Test plan
- [ ] Import warehouse types CSV; duplicate names rejected globally
- [ ] Not runtime-tested locally