### PR TITLE
fix(MRCMS): shelter journal PDF list layout (#56)

### DIFF
--- a/modules/templates/MRCMS/models/cr.py
+++ b/modules/templates/MRCMS/models/cr.py
@@ -158,6 +158,8 @@ class CRShelterNoteModel(DataModel):
         self.configure(tablename,
                        filter_widgets = filter_widgets,
                        list_fields = list_fields,
+                       pdf_format = "list",
+                       pdf_fields = list_fields,
                        onaccept = self.shelter_note_onaccept,
                        orderby = "%s.date desc" % tablename,
                        super_entity = "doc_entity",


### PR DESCRIPTION
## Summary
Fixes MRCMS shelter journal PDF `LayoutError` by using list layout (#56).

## Test plan
- [ ] Export shelter journal as PDF — no crash
- [ ] Not runtime-tested locally