### PR TITLE
fix: ADMIN lookup dropdowns empty (#1)

### DIFF
--- a/modules/s3db/hrm.py
+++ b/modules/s3db/hrm.py
@@ -122,7 +122,7 @@ class HRModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:
@@ -2096,7 +2096,7 @@ class HRSkillModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:
@@ -4848,7 +4848,7 @@ class HRProgrammeModel(DataModel):
 
         label_create = crud_strings[tablename].label_create
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/member.py
+++ b/modules/s3db/member.py
@@ -65,7 +65,7 @@ class MemberModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/org.py
+++ b/modules/s3db/org.py
@@ -5023,7 +5023,7 @@ class OrgOfficeModel(DataModel):
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/pr.py
+++ b/modules/s3db/pr.py
@@ -4982,7 +4982,7 @@ class PREducationModel(DataModel):
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/vol.py
+++ b/modules/s3db/vol.py
@@ -604,7 +604,7 @@ class VolunteerAwardModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:


### PR DESCRIPTION
## Summary
Fixes empty ADMIN dropdowns: `filter_opts = None` instead of `()` so `IS_ONE_OF` is not filtered to empty set (#1).

Partial fix — see #102 for `filterOptionsS3` + global office types setting.

## Test plan
- [ ] Login as ADMIN without root org: office type dropdown shows options
- [ ] Not runtime-tested locally