### PR TITLE
feat(gis): opt-in MAP2 map viewing client (#23)

### DIFF
--- a/controllers/gis.py
+++ b/controllers/gis.py
@@ -83,6 +83,11 @@ def map_viewing_client():
         UI for a user to view the overall Maps with associated Features
     """
 
+    if settings.get_gis_map_viewing_client() == "map2":
+        from core.gis.base import MAP2
+        response.title = T("Map Viewing Client")
+        return {"map": MAP2(catalogue_layers = True)}
+
     # Read user request
     print_mode = get_vars.get("print", None)
     if print_mode:

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -1791,6 +1791,14 @@ class S3Config(Storage):
         """
         return self.gis.get("save", True)
 
+    def get_gis_map_viewing_client(self):
+        """
+            Map viewing client implementation:
+                - "legacy" : OpenLayers 2 MAP widget (default)
+                - "map2"   : OpenLayers 6 MAP2 widget (WIP)
+        """
+        return self.gis.get("map_viewing_client", "legacy")
+
     def get_gis_scaleline(self):
         """
             Should the Map display a ScaleLine control?

--- a/modules/templates/000_config.py
+++ b/modules/templates/000_config.py
@@ -116,6 +116,8 @@ settings.auth.hmac_key = "akeytochange"
 
 # Uncomment to restrict to specific country/countries
 #settings.gis.countries= ("LK",)
+# Map viewing client: "legacy" (OpenLayers 2) or "map2" (OpenLayers 6 WIP)
+#settings.gis.map_viewing_client = "map2"
 
 # Bing API Key (for Map layers)
 # http://www.microsoft.com/maps/create-a-bing-maps-key.aspx


### PR DESCRIPTION
## Summary
Opt-in MAP2 map viewing client pilot for #23 (`settings.gis.map_viewing_client`).

Incremental step — full OpenLayers 6 modernization tracked separately (@awjans).

## Test plan
- [ ] Set `map_viewing_client = 'map2'`: map views use MAP2 client
- [ ] Default `legacy`: unchanged behaviour
- [ ] Not runtime-tested locally