### PR TITLE
feat(org): filterOptionsS3 for office types + global-only setting (#1)

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -4982,6 +4982,13 @@ class S3Config(Storage):
         """
         return self.org.get("office_code_unique", False)
 
+    def get_org_office_type_global_only(self):
+        """
+            Use only global office types (organisation_id IS NULL)
+            instead of organisation-scoped types
+        """
+        return self.org.get("office_type_global_only", False)
+
     def get_org_facility_code_unique(self):
         """
             Whether Facility code is unique

--- a/modules/s3db/hrm.py
+++ b/modules/s3db/hrm.py
@@ -122,7 +122,7 @@ class HRModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:
@@ -2096,7 +2096,7 @@ class HRSkillModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:
@@ -4848,7 +4848,7 @@ class HRProgrammeModel(DataModel):
 
         label_create = crud_strings[tablename].label_create
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/member.py
+++ b/modules/s3db/member.py
@@ -65,7 +65,7 @@ class MemberModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/org.py
+++ b/modules/s3db/org.py
@@ -5023,7 +5023,7 @@ class OrgOfficeModel(DataModel):
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/org.py
+++ b/modules/s3db/org.py
@@ -5022,7 +5022,9 @@ class OrgOfficeModel(DataModel):
         ADMIN = current.session.s3.system_roles.ADMIN
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
-        if is_admin:
+        if settings.get_org_office_type_global_only():
+            filter_opts = (None,)
+        elif is_admin:
             filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
@@ -5064,6 +5066,24 @@ class OrgOfficeModel(DataModel):
             msg_list_empty = T("No Office Types currently registered"))
 
         represent = S3Represent(lookup=tablename, translate=True)
+        office_type_comment = TAG[""](
+            PopupLink(c = "org",
+                      f = "office_type",
+                      label = ADD_OFFICE_TYPE,
+                      title = T("Office Type"),
+                      tooltip = T("If you don't see the Type in the list, you can add a new one by clicking link 'Create Office Type'."),
+                      ),
+            SCRIPT(
+'''$.filterOptionsS3({
+ 'trigger':'organisation_id',
+ 'target':'office_type_id',
+ 'lookupPrefix':'org',
+ 'lookupResource':'office_type',
+ 'lookupField':'organisation_id',
+ 'optional':true
+})'''
+            ),
+            )
         office_type_id = FieldTemplate("office_type_id", "reference %s" % tablename,
                                        label = T("Office Type"),
                                        ondelete = "SET NULL",
@@ -5076,12 +5096,7 @@ class OrgOfficeModel(DataModel):
                                                               filter_opts=filter_opts,
                                                               )),
                                        sortby = "name",
-                                       comment = PopupLink(c = "org",
-                                                           f = "office_type",
-                                                           label = ADD_OFFICE_TYPE,
-                                                           title = T("Office Type"),
-                                                           tooltip = T("If you don't see the Type in the list, you can add a new one by clicking link 'Create Office Type'."),
-                                                           ),
+                                       comment = office_type_comment,
                                        )
 
         configure(tablename,

--- a/modules/s3db/pr.py
+++ b/modules/s3db/pr.py
@@ -4982,7 +4982,7 @@ class PREducationModel(DataModel):
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:

--- a/modules/s3db/vol.py
+++ b/modules/s3db/vol.py
@@ -604,7 +604,7 @@ class VolunteerAwardModel(DataModel):
 
         root_org = auth.root_org()
         if is_admin:
-            filter_opts = ()
+            filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
         else:


### PR DESCRIPTION
## Summary

Follow-up to #99 (ADMIN empty dropdown fix) per @nursix guidance on #1:

- **`filterOptionsS3`** on the office form: `office_type_id` options refresh when `organisation_id` is chosen
- **`settings.org.office_type_global_only`**: when enabled, only global office types (`organisation_id IS NULL`) are shown regardless of org context

## Context

- Builds on #99 (`filter_opts = None` for ADMIN)
- Addresses the remaining maintainer request on #1 (dynamic org-scoped dropdowns + global-types setting)

## Test plan

- [ ] Create/edit office as ADMIN: choose organisation → office type dropdown populates
- [ ] Enable `office_type_global_only` → only global types appear
- [ ] Not runtime-tested locally (needs web2py stack)


Made with [Cursor](https://cursor.com)