### PR TITLE
fix(DIRECT): seed warehouse types for dropdown (#46)

### DIFF
--- a/modules/templates/DIRECT/inv_warehouse_type.csv
+++ b/modules/templates/DIRECT/inv_warehouse_type.csv
@@ -1,0 +1,3 @@
+Name,Comments
+Central Warehouse,
+Field Warehouse,

--- a/modules/templates/DIRECT/tasks.cfg
+++ b/modules/templates/DIRECT/tasks.cfg
@@ -38,4 +38,6 @@ gis,layer_config,default/gis_layer_openstreetmap.csv,layer_openstreetmap.xsl
 # ORG -------------------------------------------------------------------------
 org,sector,default/org_sector.csv,sector.xsl
 org,service,org_service.csv,service.xsl
+# INV -------------------------------------------------------------------------
+inv,warehouse_type,inv_warehouse_type.csv,warehouse_type.xsl
 # =============================================================================


### PR DESCRIPTION
## Summary
Fixes #46.

Re-submitted against **`dev`** per @nursix review on #96 (previous PR targeted `master`).

Seeds warehouse types via DIRECT template import so the Warehouse Type dropdown is populated.

## Test plan
- [x] Cherry-picked onto current `dev`; CSV + `tasks.cfg` apply cleanly
- [ ] Maintainer verify on DIRECT deployment

Supersedes closed #96.

Made with [Cursor](https://cursor.com)