### PR TITLE
fix(MRCMS): shelter journal PDF list layout (#56)

### DIFF
--- a/modules/templates/MRCMS/models/cr.py
+++ b/modules/templates/MRCMS/models/cr.py
@@ -158,6 +158,8 @@ class CRShelterNoteModel(DataModel):
         self.configure(tablename,
                        filter_widgets = filter_widgets,
                        list_fields = list_fields,
+                       pdf_format = "list",
+                       pdf_fields = list_fields,
                        onaccept = self.shelter_note_onaccept,
                        orderby = "%s.date desc" % tablename,
                        super_entity = "doc_entity",


### PR DESCRIPTION
## Summary
Fixes #56.

Re-submitted against **`dev`** per @nursix review on #98.

Sets `pdf_format = "list"` and `pdf_fields = list_fields` on shelter journal export to avoid LayoutError.

## Test plan
- [x] Cherry-picked onto current `dev`
- [ ] Maintainer PDF export smoke test on MRCMS

Supersedes closed #98.

Made with [Cursor](https://cursor.com)