### PR TITLE
feat(org): filterOptionsS3 for office types + global-only setting (#1)

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -4972,6 +4972,13 @@ class S3Config(Storage):
         """
         return self.org.get("office_code_unique", False)
 
+    def get_org_office_type_global_only(self):
+        """
+            Use only global office types (organisation_id IS NULL)
+            instead of organisation-scoped types
+        """
+        return self.org.get("office_type_global_only", False)
+
     def get_org_facility_code_unique(self):
         """
             Whether Facility code is unique

--- a/modules/s3db/org.py
+++ b/modules/s3db/org.py
@@ -5022,7 +5022,9 @@ class OrgOfficeModel(DataModel):
         ADMIN = current.session.s3.system_roles.ADMIN
         is_admin = auth.s3_has_role(ADMIN)
         root_org = auth.root_org()
-        if is_admin:
+        if settings.get_org_office_type_global_only():
+            filter_opts = (None,)
+        elif is_admin:
             filter_opts = None
         elif root_org:
             filter_opts = (root_org, None)
@@ -5064,6 +5066,24 @@ class OrgOfficeModel(DataModel):
             msg_list_empty = T("No Office Types currently registered"))
 
         represent = S3Represent(lookup=tablename, translate=True)
+        office_type_comment = TAG[""](
+            PopupLink(c = "org",
+                      f = "office_type",
+                      label = ADD_OFFICE_TYPE,
+                      title = T("Office Type"),
+                      tooltip = T("If you don't see the Type in the list, you can add a new one by clicking link 'Create Office Type'."),
+                      ),
+            SCRIPT(
+'''$.filterOptionsS3({
+ 'trigger':'organisation_id',
+ 'target':'office_type_id',
+ 'lookupPrefix':'org',
+ 'lookupResource':'office_type',
+ 'lookupField':'organisation_id',
+ 'optional':true
+})'''
+            ),
+            )
         office_type_id = FieldTemplate("office_type_id", "reference %s" % tablename,
                                        label = T("Office Type"),
                                        ondelete = "SET NULL",
@@ -5076,12 +5096,7 @@ class OrgOfficeModel(DataModel):
                                                               filter_opts=filter_opts,
                                                               )),
                                        sortby = "name",
-                                       comment = PopupLink(c = "org",
-                                                           f = "office_type",
-                                                           label = ADD_OFFICE_TYPE,
-                                                           title = T("Office Type"),
-                                                           tooltip = T("If you don't see the Type in the list, you can add a new one by clicking link 'Create Office Type'."),
-                                                           ),
+                                       comment = office_type_comment,
                                        )
 
         configure(tablename,


### PR DESCRIPTION
## Summary
Partial fix for #1.

Re-submitted against **`dev`** per @nursix review on #102. Builds on the ADMIN `filter_opts = None` fix already present on `dev`.

- `filterOptionsS3` on office form: office types refresh when organisation is chosen
- `settings.org.office_type_global_only` for deployments that want global types only

## Test plan
- [x] Cherry-picked onto current `dev` (ADMIN filter fix omitted as already merged)
- [ ] Maintainer verify office form dropdown behaviour

Supersedes closed #102. Closed #99 separately — same ADMIN fix already on `dev`.

Made with [Cursor](https://cursor.com)