### PR TITLE
feat(auth): unlock locked account via email (#17)

### DIFF
--- a/controllers/default.py
+++ b/controllers/default.py
@@ -1110,6 +1110,10 @@ def user():
         title = response.title = T("Confirm Registration")
         form = auth.verify_email()
 
+    elif arg == "verify_unlock":
+        title = response.title = T("Unlock Account")
+        form = auth.verify_unlock()
+
     else:
         # logout or other function
         title = ""

--- a/modules/core/aaa/auth.py
+++ b/modules/core/aaa/auth.py
@@ -213,13 +213,16 @@ Thank you"""
  Thank you"""
         messages.unlock_email_subject = "%(system_name)s - Unlock Account"
         messages.unlock_email = \
-"""Your account on %(system_name)s has been locked due to excessive failed login attempts.
+"""Your account on %(system_name)s has been temporarily locked due to excessive failed login attempts.
 
 To unlock your account, open this link:
 %(url)s
 
 Your unlock code is: %(code)s"""
+        messages.unlock_email_sent = \
+"""Your password was correct. Please check your email for instructions to unlock your account."""
         messages.user_unlocked_log = "User %%(%s)s unlocked via email verification" % settings.login_userfield
+        messages.user_prelim_locked_log = "User %%(%s)s preliminarily locked" % settings.login_userfield
 
         # Log messages
         messages.user_disabled_log = "User %(user_id)s disabled"
@@ -324,6 +327,9 @@ Your unlock code is: %(code)s"""
                       default="",
                       readable=False, writable=False),
                 Field("locked", "boolean",
+                      default=False,
+                      readable=False, writable=False),
+                Field("email_verified", "boolean",
                       default=False,
                       readable=False, writable=False),
                 Field("failed_attempts", "integer",
@@ -540,9 +546,18 @@ Your unlock code is: %(code)s"""
         query = (utable[userfield] == username)
         user = current.db(query).select(limitby=(0, 1)).first()
 
+        if user:
+            if self.is_user_hard_locked(user):
+                self.handle_failed_login(user=user)
+                return False
+
         if user and not user.registration_key:
             password = utable[passfield].validate(password)[0]
             if user[passfield] == password:
+                if self.is_user_preliminarily_locked(user):
+                    if self.handle_correct_password_while_locked(user):
+                        current.session.information = self.messages.unlock_email_sent
+                    return False
                 user = Storage(filter_fields(utable, user, allow_id=True))
                 current.session.auth = Storage(user = user,
                                                last_visit = current.request.now,
@@ -749,9 +764,8 @@ Your unlock code is: %(code)s"""
                     # User in db
                     existing = temp_user = user
 
-                    # Check if login is permitted
-                    if self.is_user_locked(temp_user):
-                        # Account is locked due to too many failed login attempts
+                    # Hard-locked accounts cannot attempt login
+                    if self.is_user_hard_locked(temp_user):
                         self.handle_failed_login(user=temp_user)
                         response.error = messages.login_attempts_exceeded
                         response.error_code = 423
@@ -863,6 +877,21 @@ Your unlock code is: %(code)s"""
 
         # Process authenticated users
         if user:
+            # Preliminary lock: correct password triggers unlock email, not login
+            if self.is_user_preliminarily_locked(user):
+                if self.handle_correct_password_while_locked(user):
+                    session.information = messages.unlock_email_sent
+                else:
+                    response.error = messages.login_attempts_exceeded
+                    response.error_code = 423
+                if inline:
+                    next_url = URL(args=request.args,
+                                   vars=request.get_vars)
+                else:
+                    next_url = self.url(args=request.args,
+                                        vars=request.get_vars)
+                redirect(next_url)
+
             user = Storage(filter_fields(utable, user, allow_id=True))
             self.login_user(user)
         if log and self.user:
@@ -1829,6 +1858,10 @@ $('form.auth_consent').submit(S3ClearNavigateAwayConfirm);''')
                 session.error = T("Registration not found")
                 redirect(auth_settings.verify_email_next)
 
+            # Email address confirmed by activation code
+            current.db(utable.id == user.id).update(email_verified=True)
+            user.email_verified = True
+
             if log == DEFAULT:
                 log = self.messages.verify_email_log
             if next == DEFAULT:
@@ -1897,12 +1930,14 @@ $('form.auth_consent').submit(S3ClearNavigateAwayConfirm);''')
 
             auth_settings = self.settings
             code = form.vars.activation_code
+            stored_hash = self.keyhash(key, code)
 
             utable = auth_settings.table_user
-            query = (utable.reset_password_key == self.keyhash(key, code)) & \
-                    (utable.registration_key == LOCKED)
+            query = (utable.locked == True) & \
+                    (utable.registration_key != LOCKED) & \
+                    (utable.reset_password_key.like("%%:%s" % stored_hash))
             user = current.db(query).select(limitby=(0, 1)).first()
-            if not user:
+            if not user or not self.verify_unlock_token(user, key, code):
                 session.error = T("Unlock verification failed")
                 redirect(settings.get_auth_verify_unlock_next())
 
@@ -1912,7 +1947,6 @@ $('form.auth_consent').submit(S3ClearNavigateAwayConfirm);''')
                 next = settings.get_auth_verify_unlock_next()
 
             self.unlock_user(user, log=log, notify=True)
-            user.update_record(reset_password_key = "")
 
             session.confirmation = T("Your account has been unlocked. You can now log in.")
             redirect(next)
@@ -3034,7 +3068,9 @@ Please go to %(url)s to approve this user."""
             return
 
         # Allow them to login (enable the account)
-        db(utable.id == user_id).update(registration_key="")
+        db(utable.id == user_id).update(registration_key="",
+                                        email_verified=True,
+                                        )
 
         # Approve User's Organisation (if they created a new one during registration)
         if organisation_id and \

--- a/modules/core/aaa/auth.py
+++ b/modules/core/aaa/auth.py
@@ -68,6 +68,7 @@ class AuthS3(AccountLockingMixin, Auth):
             - register
             - email_reset_password
             - verify_email
+            - verify_unlock
             - profile
             - has_membership
             - requires_membership
@@ -210,6 +211,15 @@ Thank you"""
 """Your account on %(system_name)s has been unlocked.
  - You can now log in again.
  Thank you"""
+        messages.unlock_email_subject = "%(system_name)s - Unlock Account"
+        messages.unlock_email = \
+"""Your account on %(system_name)s has been locked due to excessive failed login attempts.
+
+To unlock your account, open this link:
+%(url)s
+
+Your unlock code is: %(code)s"""
+        messages.user_unlocked_log = "User %%(%s)s unlocked via email verification" % settings.login_userfield
 
         # Log messages
         messages.user_disabled_log = "User %(user_id)s disabled"
@@ -1834,6 +1844,80 @@ $('form.auth_consent').submit(S3ClearNavigateAwayConfirm);''')
 
             redirect(next)
 
+        return form
+
+    # -------------------------------------------------------------------------
+    def verify_unlock(self, next=DEFAULT, log=DEFAULT):
+        """
+            Form to unlock a locked account using the code sent by email
+        """
+
+        T = current.T
+
+        request = current.request
+        response = current.response
+        session = current.session
+
+        settings = current.deployment_settings
+
+        from .lock import LOCKED
+
+        if request.env.request_method == "POST":
+            key = request.post_vars.registration_key
+        elif len(request.args) > 1:
+            key = request.args[-1]
+        else:
+            key = None
+        if not key:
+            session.error = T("Missing unlock key")
+            redirect(URL(c="default", f="index"))
+
+        formfields = [Field("activation_code",
+                            label = T("Please enter your Unlock Code"),
+                            requires = IS_NOT_EMPTY(),
+                            ),
+                      ]
+
+        response.form_label_separator = ""
+        form = SQLFORM.factory(table_name = "auth_user",
+                               record = None,
+                               hidden = {"_next": request.vars._next,
+                                         "registration_key": key,
+                                         },
+                               separator = ":",
+                               showid = False,
+                               submit_button = T("Submit"),
+                               formstyle = settings.get_ui_formstyle(),
+                               *formfields)
+
+        if form.accepts(request.vars,
+                        session,
+                        formname = "unlock_confirm",
+                        ):
+
+            auth_settings = self.settings
+            code = form.vars.activation_code
+
+            utable = auth_settings.table_user
+            query = (utable.reset_password_key == self.keyhash(key, code)) & \
+                    (utable.registration_key == LOCKED)
+            user = current.db(query).select(limitby=(0, 1)).first()
+            if not user:
+                session.error = T("Unlock verification failed")
+                redirect(settings.get_auth_verify_unlock_next())
+
+            if log == DEFAULT:
+                log = self.messages.user_unlocked_log
+            if next == DEFAULT:
+                next = settings.get_auth_verify_unlock_next()
+
+            self.unlock_user(user, log=log, notify=True)
+            user.update_record(reset_password_key = "")
+
+            session.confirmation = T("Your account has been unlocked. You can now log in.")
+            redirect(next)
+
+        response.title = T("Unlock Account")
         return form
 
     # -------------------------------------------------------------------------

--- a/modules/core/aaa/lock.py
+++ b/modules/core/aaa/lock.py
@@ -26,22 +26,26 @@
 """
 
 import datetime
+import time
 
 from gluon import current, URL
 from uuid import uuid4
 
 LOCKED = "failed"
 
+# Additional failed attempts after the preliminary threshold before hard lock
+HARD_LOCK_EXTRA_ATTEMPTS = 5
+
 # =============================================================================
 class AccountLockingMixin:
     """ Auth mixin to handle locking of accounts """
 
-    def is_user_locked(self, user):
+    def is_user_hard_locked(self, user):
         """
-            Checks whether a user account is (still) locked
+            Checks whether a user account is hard-locked (ADMIN unlock only)
 
             Args:
-                user: the user account (auth_user Row)
+                user: the auth_user Row
 
             Returns:
                 boolean
@@ -53,47 +57,102 @@ class AccountLockingMixin:
         return not user.locked_until or user.locked_until > current.request.utcnow
 
     # -------------------------------------------------------------------------
+    def is_user_preliminarily_locked(self, user):
+        """
+            Checks whether a user account is preliminarily locked
+            (self-service email unlock may still be available)
+
+            Args:
+                user: the auth_user Row
+
+            Returns:
+                boolean
+        """
+
+        return user and user.locked and not self.is_user_hard_locked(user)
+
+    # -------------------------------------------------------------------------
+    def is_user_locked(self, user):
+        """
+            Checks whether a user account is locked (preliminary or hard)
+
+            Args:
+                user: the auth_user Row
+
+            Returns:
+                boolean
+        """
+
+        return self.is_user_hard_locked(user) or self.is_user_preliminarily_locked(user)
+
+    # -------------------------------------------------------------------------
+    def can_send_unlock_email(self, user):
+        """
+            Whether self-service email unlock is available for this user
+
+            Args:
+                user: the auth_user Row
+
+            Returns:
+                boolean
+        """
+
+        settings = current.deployment_settings
+        if not settings.get_auth_email_unlock():
+            return False
+
+        mailer = self.settings.mailer
+        if not mailer or not mailer.settings.server:
+            return False
+
+        if not user or not user.email:
+            return False
+
+        return bool(getattr(user, "email_verified", False))
+
+    # -------------------------------------------------------------------------
     def handle_failed_login(self, user=None):
         """
             Handles failed logins:
-                - locks the user account when there are too many failed login
-                  attempts (possibly with a lock timeout, if configured)
+                - preliminarily locks the account after the 1st threshold
+                - hard-locks the account after the 2nd threshold
 
             Args:
                 user: the user record (or None)
 
             Notes:
-                - the lock timeout progresses for every further attempt to
-                  login to a locked account
-                - ADMIN accounts always get a lock timeout, even when other
-                  accounts are locked indefinitely
+                - the lock timeout applies to hard locks
+                - ADMIN accounts always get a lock timeout on hard lock
+                - invalidates pending unlock tokens on further failures
                 - additionally invalidates the session to interrupt serial
-                  login failures
+                  login failures against hard-locked accounts
         """
 
         session = current.session
         deployment_settings = current.deployment_settings
         messages = self.messages
 
-        # Get the Auth Lock settings
         max_failed_logins = deployment_settings.get_auth_max_failed_logins()
+        hard_threshold = deployment_settings.get_auth_max_failed_logins_hard()
         lock_timeout = deployment_settings.get_auth_failed_login_lock_timeout()
 
-        # Check if the Failed Login Count is greater than 0 (0 means no lock policy)
         if user and max_failed_logins:
 
-            prev = user.registration_key == LOCKED
-            locking = False
+            prev_hard = user.registration_key == LOCKED
+            prev_prelim = user.locked
+            hard_locking = False
+            prelim_locking = False
 
             failed_attempts = (user.failed_attempts or 0) + 1
             update = {"failed_attempts": failed_attempts}
 
-            if failed_attempts >= max_failed_logins:
-                # Mandatory lock-timeout for ADMIN accounts
-                # Check directly in database since user is not logged in yet
+            # Invalidate any pending unlock token
+            if user.reset_password_key:
+                update["reset_password_key"] = ""
+
+            if failed_attempts >= hard_threshold:
                 db = current.db
                 ADMIN = self.get_system_roles().ADMIN
-             
 
                 mtable = db.auth_membership
                 query = (mtable.user_id == user.id) & \
@@ -103,34 +162,62 @@ class AccountLockingMixin:
 
                 if not lock_timeout and is_admin:
                     lock_timeout = 300 # seconds
-                # Determine lock-timeout
+
                 if lock_timeout:
                     locked_until = datetime.datetime.utcnow() + \
                                    datetime.timedelta(seconds=lock_timeout)
                 else:
                     locked_until = None
 
-                locking = not prev
+                hard_locking = not prev_hard
                 update["registration_key"] = LOCKED
+                update["locked"] = True
                 update["locked_until"] = locked_until
 
-                if failed_attempts > max_failed_logins + 3:
-                    # User is ignoring the lock => interrupt their flow
-                    # by invalidating the session
+                if failed_attempts > hard_threshold + 3:
                     session.invalid = True
                     session.error = messages.login_attempts_exceeded
-                    update["failed_attempts"] = max_failed_logins
+                    update["failed_attempts"] = hard_threshold
+
+            elif failed_attempts >= max_failed_logins:
+                prelim_locking = not prev_prelim and not prev_hard
+                update["locked"] = True
+                update["registration_key"] = None
+                update["locked_until"] = None
+
             else:
+                update["locked"] = False
                 update["registration_key"] = None
                 update["locked_until"] = None
 
             user.update_record(**update)
 
-            if locking:
-                # Log the event
+            if hard_locking:
                 self.log_event(self.messages.user_locked_log, user)
-                # Notify the user by email
                 self.send_user_locked_email(user)
+            elif prelim_locking:
+                self.log_event(self.messages.user_prelim_locked_log, user)
+
+    # -------------------------------------------------------------------------
+    def handle_correct_password_while_locked(self, user):
+        """
+            Handle a correct password entered while the account is
+            preliminarily locked: send unlock email if eligible
+
+            Args:
+                user: the auth_user Row
+
+            Returns:
+                boolean - True if unlock email was sent
+        """
+
+        if not self.is_user_preliminarily_locked(user):
+            return False
+
+        if self.can_send_unlock_email(user):
+            return self.send_account_unlock_email(user)
+
+        return False
 
     # -------------------------------------------------------------------------
     def unlock_user(self, user, log=None, notify=False):
@@ -153,14 +240,17 @@ class AccountLockingMixin:
 
             update = {}
 
-            if user.registration_key == LOCKED:
+            if user.registration_key == LOCKED or user.locked:
                 update["registration_key"] = None
+                update["locked"] = False
             else:
                 log = notify = False
             if "failed_attempts" not in user or user.failed_attempts:
                 update["failed_attempts"] = 0
             if "locked_until" not in user or user.locked_until:
                 update["locked_until"] = None
+            if user.reset_password_key:
+                update["reset_password_key"] = ""
 
             if update:
                 table = self.settings.table_user
@@ -168,18 +258,56 @@ class AccountLockingMixin:
 
                 user.update(update)
 
-                # Log the event
                 if log:
                     self.log_event(log, user)
 
-                # Notify the user by email
                 if notify:
                     self.send_user_unlocked_email(user)
 
     # -------------------------------------------------------------------------
+    def send_account_unlock_email(self, user):
+        """
+            Send an email with link/code to lift a preliminary lock
+
+            Args:
+                user: the auth_user record (Row)
+
+            Returns:
+                True if email sent successfully, else False
+        """
+
+        mailer = self.settings.mailer
+        if not mailer or not mailer.settings.server:
+            return False
+
+        messages = self.messages
+        system_name = current.deployment_settings.get_system_name()
+
+        key = str(uuid4())
+        code = uuid4().hex[-6:].upper()
+        token = "%d:%s" % (int(time.time()), self.keyhash(key, code))
+        user.update_record(reset_password_key = token)
+
+        url = URL(c = "default",
+                  f = "user",
+                  args = ["verify_unlock", key],
+                  scheme = True)
+
+        subject = messages.unlock_email_subject % {"system_name": system_name}
+        message = messages.unlock_email % {"system_name": system_name,
+                                           "url": url,
+                                           "code": code,
+                                           }
+
+        return bool(mailer.send(to = user.email,
+                                subject = subject,
+                                message = message,
+                                ))
+
+    # -------------------------------------------------------------------------
     def send_user_locked_email(self, user):
         """
-            Send an email to the user when their account is locked
+            Send an email to the user when their account is hard-locked
                 - due to excessive failed login attempts
 
             Args:
@@ -195,25 +323,9 @@ class AccountLockingMixin:
 
         messages = self.messages
         system_name = current.deployment_settings.get_system_name()
-        settings = current.deployment_settings
 
         subject = messages.locked_email_subject % {"system_name": system_name}
         message = messages.locked_email % {"system_name": system_name}
-
-        if settings.get_auth_email_unlock():
-            key = str(uuid4())
-            code = uuid4().hex[-6:].upper()
-            user.update_record(reset_password_key = self.keyhash(key, code))
-            url = URL(c = "default",
-                      f = "user",
-                      args = ["verify_unlock", key],
-                      scheme = True)
-            subject = messages.unlock_email_subject % {"system_name": system_name}
-            message = messages.unlock_email % {"system_name": system_name,
-                                               "url": url,
-                                               "code": code,
-                                               }
-
         return bool(mailer.send(to = user.email,
                                 subject = subject,
                                 message = message,
@@ -245,5 +357,35 @@ class AccountLockingMixin:
                                 subject = subject,
                                 message = message,
                                 ))
+
+    # -------------------------------------------------------------------------
+    def verify_unlock_token(self, user, key, code):
+        """
+            Validate an unlock token and check whether it has expired
+
+            Args:
+                user: the auth_user Row
+                key: the unlock key from the URL
+                code: the activation code from the form
+
+            Returns:
+                boolean
+        """
+
+        token = user.reset_password_key
+        if not token:
+            return False
+
+        timeout = current.deployment_settings.get_auth_unlock_token_timeout()
+        stored_hash = token
+        if ":" in token:
+            timestamp, stored_hash = token.split(":", 1)
+            try:
+                if int(time.time()) - int(timestamp) > timeout:
+                    return False
+            except ValueError:
+                return False
+
+        return stored_hash == self.keyhash(key, code)
 
 # END =========================================================================

--- a/modules/core/aaa/lock.py
+++ b/modules/core/aaa/lock.py
@@ -27,7 +27,8 @@
 
 import datetime
 
-from gluon import current
+from gluon import current, URL
+from uuid import uuid4
 
 LOCKED = "failed"
 
@@ -194,9 +195,25 @@ class AccountLockingMixin:
 
         messages = self.messages
         system_name = current.deployment_settings.get_system_name()
+        settings = current.deployment_settings
 
         subject = messages.locked_email_subject % {"system_name": system_name}
         message = messages.locked_email % {"system_name": system_name}
+
+        if settings.get_auth_email_unlock():
+            key = str(uuid4())
+            code = uuid4().hex[-6:].upper()
+            user.update_record(reset_password_key = self.keyhash(key, code))
+            url = URL(c = "default",
+                      f = "user",
+                      args = ["verify_unlock", key],
+                      scheme = True)
+            subject = messages.unlock_email_subject % {"system_name": system_name}
+            message = messages.unlock_email % {"system_name": system_name,
+                                               "url": url,
+                                               "code": code,
+                                               }
+
         return bool(mailer.send(to = user.email,
                                 subject = subject,
                                 message = message,

--- a/modules/core/methods/account.py
+++ b/modules/core/methods/account.py
@@ -112,6 +112,7 @@ class ManageUserAccount(CRUDMethod):
         # Enable/unlock user account
         user.update_record(registration_key = None,
                            failed_attempts = 0,
+                           locked = False,
                            locked_until = None,
                            )
 

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -607,6 +607,19 @@ class S3Config(Storage):
             return lock_timeout
         return None
 
+    def get_auth_email_unlock(self):
+        """
+            Allow locked users to unlock their account via email
+            verification (link + activation code)
+        """
+        return self.auth.get("email_unlock", True)
+
+    def get_auth_verify_unlock_next(self):
+        """
+            Redirect target after a successful email unlock
+        """
+        return self.auth.get("verify_unlock_next", URL(c="default", f="user", args="login"))
+
     def get_auth_password_changes(self):
         """
             Are password changes allowed?

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -607,12 +607,35 @@ class S3Config(Storage):
             return lock_timeout
         return None
 
+    def get_auth_max_failed_logins_hard(self):
+        """
+            Maximum failed login attempts before hard lock (ADMIN unlock only)
+            - defaults to get_auth_max_failed_logins() + HARD_LOCK_EXTRA_ATTEMPTS
+        """
+        hard = self.auth.get("max_failed_logins_hard", None)
+        if isinstance(hard, int) and hard > 0:
+            return hard
+        soft = self.get_auth_max_failed_logins()
+        if soft:
+            from core.aaa.lock import HARD_LOCK_EXTRA_ATTEMPTS
+            return soft + HARD_LOCK_EXTRA_ATTEMPTS
+        return None
+
     def get_auth_email_unlock(self):
         """
-            Allow locked users to unlock their account via email
-            verification (link + activation code)
+            Allow preliminarily locked users to unlock via email verification
+            (actual availability also requires a configured mail server)
         """
         return self.auth.get("email_unlock", True)
+
+    def get_auth_unlock_token_timeout(self):
+        """
+            Seconds until an unlock token expires
+        """
+        timeout = self.auth.get("unlock_token_timeout", 3600)
+        if isinstance(timeout, int) and timeout > 0:
+            return timeout
+        return 3600
 
     def get_auth_verify_unlock_next(self):
         """

--- a/modules/templates/000_config.py
+++ b/modules/templates/000_config.py
@@ -86,6 +86,8 @@ settings.base.debug = False
 #settings.auth.max_login_attempts = 3
 # Timeout (seconds) for locking an account after max failed logins
 #settings.auth.failed_login_lock_timeout = 300
+# Allow locked users to unlock via email link + code (requires mail server)
+#settings.auth.email_unlock = True
 
 # This setting should be changed _before_ registering the 1st user
 # - should happen automatically if installing using supported scripts

--- a/modules/templates/000_config.py
+++ b/modules/templates/000_config.py
@@ -83,11 +83,15 @@ settings.base.debug = False
 
 # Authentication settings
 # Maxmimum number of failed login attempts before an account is locked
-#settings.auth.max_login_attempts = 3
+#settings.auth.max_failed_logins = 3
+# Hard lock threshold (defaults to max_failed_logins + 5)
+#settings.auth.max_failed_logins_hard = 8
 # Timeout (seconds) for locking an account after max failed logins
 #settings.auth.failed_login_lock_timeout = 300
-# Allow locked users to unlock via email link + code (requires mail server)
+# Allow preliminarily locked users to unlock via email (requires mail server + verified email)
 #settings.auth.email_unlock = True
+# Unlock token expiry (seconds)
+#settings.auth.unlock_token_timeout = 3600
 
 # This setting should be changed _before_ registering the 1st user
 # - should happen automatically if installing using supported scripts

--- a/modules/unit_tests/core/aaa/auth.py
+++ b/modules/unit_tests/core/aaa/auth.py
@@ -2540,6 +2540,195 @@ class LinkToPersonTests(unittest.TestCase):
         assertTrue(person2.id in person_ids)
 
 # =============================================================================
+class AccountLockingTests(unittest.TestCase):
+    """ Two-tier account locking and email unlock tests """
+
+    # -------------------------------------------------------------------------
+    def setUp(self):
+
+        auth = current.auth
+        auth.override = True
+        auth.s3_impersonate(None)
+
+        settings = current.deployment_settings
+        auth_settings = settings.auth
+
+        self.saved_auth = Storage(max_failed_logins = auth_settings.get("max_failed_logins"),
+                                  max_failed_logins_hard = auth_settings.get("max_failed_logins_hard"),
+                                  email_unlock = auth_settings.get("email_unlock", True),
+                                  unlock_token_timeout = auth_settings.get("unlock_token_timeout"),
+                                  )
+
+        auth_settings.max_failed_logins = 3
+        auth_settings.max_failed_logins_hard = 6
+        auth_settings.email_unlock = True
+        auth_settings.unlock_token_timeout = 3600
+
+        utable = auth.settings.table_user
+        self.utable = utable
+        self.test_email = "locktest@example.com"
+        self.test_password = "LockTest99"
+
+        db = current.db
+        db(utable.email == self.test_email).delete()
+
+        user_id = utable.insert(first_name = "Lock",
+                                last_name = "Test",
+                                email = self.test_email,
+                                password = self.test_password,
+                                email_verified = True,
+                                registration_key = None,
+                                failed_attempts = 0,
+                                locked = False,
+                                )
+        self.assertTrue(user_id is not None)
+        self.user_id = user_id
+
+        auth.override = False
+
+    # -------------------------------------------------------------------------
+    def tearDown(self):
+
+        settings = current.deployment_settings
+        auth_settings = settings.auth
+
+        auth_settings.max_failed_logins = self.saved_auth.max_failed_logins
+        auth_settings.max_failed_logins_hard = self.saved_auth.max_failed_logins_hard
+        auth_settings.email_unlock = self.saved_auth.email_unlock
+        auth_settings.unlock_token_timeout = self.saved_auth.unlock_token_timeout
+
+        current.auth.s3_impersonate(None)
+        current.db(self.utable.email == self.test_email).delete()
+        current.db.rollback()
+
+    # -------------------------------------------------------------------------
+    def _user(self):
+        """ Reload the test user record """
+
+        return current.db(self.utable.id == self.user_id).select().first()
+
+    # -------------------------------------------------------------------------
+    def _fail_login(self, count=1):
+        """ Simulate failed login attempts """
+
+        auth = current.auth
+        for _ in range(count):
+            auth.handle_failed_login(user=self._user())
+
+    # -------------------------------------------------------------------------
+    def testPreliminaryLockAfterThreshold(self):
+        """ Failed attempts at soft threshold preliminarily lock the account """
+
+        self._fail_login(3)
+        user = self._user()
+        auth = current.auth
+
+        self.assertTrue(user.locked)
+        self.assertTrue(auth.is_user_preliminarily_locked(user))
+        self.assertFalse(auth.is_user_hard_locked(user))
+
+    # -------------------------------------------------------------------------
+    def testHardLockAfterSecondThreshold(self):
+        """ Failed attempts at hard threshold require ADMIN unlock """
+
+        self._fail_login(6)
+        user = self._user()
+        auth = current.auth
+
+        self.assertTrue(auth.is_user_hard_locked(user))
+        self.assertTrue(auth.is_user_locked(user))
+
+    # -------------------------------------------------------------------------
+    def testUnlockUserClearsFlags(self):
+        """ unlock_user resets lock state and failed attempt counter """
+
+        self._fail_login(3)
+        auth = current.auth
+        user = self._user()
+
+        auth.unlock_user(user, log=None, notify=False)
+        user = self._user()
+
+        self.assertFalse(user.locked)
+        self.assertFalse(user.registration_key)
+        self.assertEqual(user.failed_attempts, 0)
+
+    # -------------------------------------------------------------------------
+    def testCanSendUnlockEmailRequiresVerifiedEmail(self):
+        """ Unlock email requires a previously verified email address """
+
+        auth = current.auth
+        user = self._user()
+
+        user.update_record(email_verified = False)
+        self.assertFalse(auth.can_send_unlock_email(self._user()))
+
+        user.update_record(email_verified = True)
+        # Mail server may be absent in test env; verified email is necessary
+        # but not sufficient when mailer is not configured
+        if auth.settings.mailer and auth.settings.mailer.settings.server:
+            self.assertTrue(auth.can_send_unlock_email(self._user()))
+
+    # -------------------------------------------------------------------------
+    def testFailedLoginInvalidatesUnlockToken(self):
+        """ Further failed attempts invalidate a pending unlock token """
+
+        user = self._user()
+        user.update_record(reset_password_key = "1234567890:deadbeef")
+
+        self._fail_login(1)
+        user = self._user()
+
+        self.assertEqual(user.reset_password_key, "")
+
+    # -------------------------------------------------------------------------
+    def testCorrectPasswordWhilePrelimLockedDoesNotLogin(self):
+        """ Correct password on prelim lock does not authenticate the user """
+
+        self._fail_login(3)
+        auth = current.auth
+
+        result = auth.login_bare(self.test_email, self.test_password)
+
+        self.assertFalse(result)
+        self.assertFalse(auth.s3_logged_in())
+        self.assertTrue(auth.is_user_preliminarily_locked(self._user()))
+
+    # -------------------------------------------------------------------------
+    def testVerifyUnlockTokenExpiry(self):
+        """ Expired unlock tokens are rejected """
+
+        import time
+        auth = current.auth
+
+        key = "test-unlock-key"
+        code = "ABC123"
+        expired = "%d:%s" % (int(time.time()) - 7200, auth.keyhash(key, code))
+        user = self._user()
+        user.update_record(reset_password_key = expired,
+                           locked = True,
+                           )
+
+        self.assertFalse(auth.verify_unlock_token(user, key, code))
+
+    # -------------------------------------------------------------------------
+    def testVerifyUnlockTokenValid(self):
+        """ Valid unlock tokens are accepted """
+
+        import time
+        auth = current.auth
+
+        key = "test-unlock-key"
+        code = "ABC123"
+        token = "%d:%s" % (int(time.time()), auth.keyhash(key, code))
+        user = self._user()
+        user.update_record(reset_password_key = token,
+                           locked = True,
+                           )
+
+        self.assertTrue(auth.verify_unlock_token(user, key, code))
+
+# =============================================================================
 if __name__ == "__main__":
 
     run_suite(
@@ -2551,6 +2740,7 @@ if __name__ == "__main__":
         RecordApprovalTests,
         RealmEntityTests,
         LinkToPersonTests,
+        AccountLockingTests,
         )
 
 # END ========================================================================


### PR DESCRIPTION
## Summary
Fixes #17.

Re-submitted against **`dev`** per @nursix review on #100.

Two-tier lock design from the issue thread:
- **Preliminary lock** after soft threshold; **hard lock** (ADMIN only) after hard threshold
- Unlock email sent **only after correct password** while preliminarily locked
- Requires `email_verified` + configured mail server (self-disables without mail)
- `verify_unlock` removes lock but does not log in; no forced password reset

## Test plan
- [x] `modules/unit_tests/core/aaa/auth.py` — **59/59 OK** on **web2py 3.3.3** (sqlite3)
- [ ] Mail-server integration smoke test (optional)

Supersedes closed #100.

Made with [Cursor](https://cursor.com)